### PR TITLE
Fix two main bugs on well swapping

### DIFF
--- a/src/everest_models/jobs/fm_well_swapping/cli.py
+++ b/src/everest_models/jobs/fm_well_swapping/cli.py
@@ -3,9 +3,6 @@
 from logging import getLogger
 from typing import Optional, Sequence
 
-from .parser import build_argument_parser
-from .state_machine import StateMachine
-from .state_processor import StateProcessor
 from .tasks import (
     clean_parsed_data,
     determine_index_states,
@@ -17,33 +14,12 @@ logger = getLogger("Well Swapping")
 
 
 def main_entry_point(args: Optional[Sequence[str]] = None):
-    args_parser = build_argument_parser()
-    options = args_parser.parse_args(args)
-    data = clean_parsed_data(options)
-    if data.errors:
-        erros = "\n".join(data.errors)
-        logger.error(erros)
-        args_parser.error(erros)
-
-    if data.lint_only:
-        args_parser.exit()
-
+    data = clean_parsed_data(args)
     inject_case_operations(
         data.cases.to_dict(),
         zip(
-            duration_to_dates(
-                data.state_duration,
-                options.config.start_date,
-            ),
-            determine_index_states(
-                zip(data.priorities, data.targets),
-                StateProcessor(
-                    state_machine=StateMachine.from_config(options.config.state),
-                    initial_states=data.initial_states,
-                    quotas=data.quotas,
-                ),
-                iterations=data.iterations,
-            ),
+            duration_to_dates(data.state_duration, data.start_date),
+            determine_index_states(data.state, data.iterations, data.priorities),
         ),
     )
     data.cases.json_dump(data.output)

--- a/src/everest_models/jobs/fm_well_swapping/parser.py
+++ b/src/everest_models/jobs/fm_well_swapping/parser.py
@@ -1,4 +1,3 @@
-from datetime import date
 from functools import partial
 from typing import Dict, Tuple
 
@@ -16,9 +15,11 @@ from ..shared.validators import (
 )
 from .models import ConfigSchema
 
-_CONFIG_ARGUMENT = "config"
+_CONFIG_ARGUMENT = "-c/--config"
 _PRIORITIES_ARGUMENT = "-p/--priorities"
-_CONSTRAINTS_ARGUMENT = "-c/--constraints"
+_CONSTRAINTS_ARGUMENT = "-cr/--constraints"
+_LIMIT_ARGUMENT = "-il/--iteration-limit"
+
 SCHEMAS = {_CONFIG_ARGUMENT: ConfigSchema}
 
 
@@ -30,15 +31,13 @@ def _clean_constraint(value: str) -> Dict[str, Tuple[float, ...]]:
 # omit anything to do with well
 @bootstrap_parser(
     schemas=SCHEMAS,  # type: ignore
-    deprication=date(2024, 5, 1),
     prog="Well Swapping",
     description="Swap well operation status over multiple time intervals.",
 )
-def build_argument_parser(
-    parser: Parser, legacy: bool = False, lint: bool = False
-) -> None:
+def build_argument_parser(parser: Parser, lint: bool = False, *_) -> None:
     parser.add_argument(
-        f"{'--' if legacy else ''}{_CONFIG_ARGUMENT}",
+        *_CONFIG_ARGUMENT.split("/"),
+        required=True,
         type=partial(parse_file, schema=ConfigSchema),
         help="well swapping configuration file",
     )
@@ -53,8 +52,7 @@ def build_argument_parser(
         help="Everest generated optimized priorities",
     )
     parser.add_argument(
-        "-il",
-        "--iteration-limit",
+        *_LIMIT_ARGUMENT.split("/"),
         default=0,
         type=partial(
             is_gt_zero, msg="limit-number-iterations must be a positive number"

--- a/src/everest_models/jobs/fm_well_swapping/state_processor.py
+++ b/src/everest_models/jobs/fm_well_swapping/state_processor.py
@@ -1,75 +1,82 @@
+from __future__ import annotations
+
+from logging import getLogger
 from typing import Dict, Iterable, Iterator, List, Tuple
 
-from .models import Case, Quota, State
+from .models import Case, Quota, State, StateConfig
 from .state_machine import StateMachine
+
+logger = getLogger("Well Swapping")
 
 
 class StateProcessor:
+    @classmethod
+    def from_state_config(
+        cls, state: StateConfig, cases: Tuple[Case, ...]
+    ) -> StateProcessor:
+        return cls(
+            state_machine=StateMachine.from_config(state),
+            initial_states=state.get_initial(cases),
+        )
+
     def __init__(
-        self,
-        state_machine: StateMachine,
-        initial_states: Dict[Case, State],
-        quotas: Dict[State, List[Quota]],
+        self, state_machine: StateMachine, initial_states: Dict[Case, State]
     ) -> None:
-        """
-        Create a StateProcessor instance.
-
-        Parameters:
-        state_machine (StateMachine): A pandas state matrix wrapper that implements `is_possible_action` and `next_possible_action`.
-        initial_states (Dict[str, str]): A map of case to it's initial state.
-        quotas (Dict[str, List[int]]): A map of state to it's quotas per iteration index.
-
-        Returns:
-        None
-        """
+        self._locked: bool = False
         self._machine: StateMachine = state_machine
         self._history: Dict[Case, List[State]] = {
             subject: [state] for subject, state in initial_states.items()
         }
-        self._quotas: Dict[State, List[Quota]] = quotas
 
-    def _recurse_state_hierarcy(self, index: int, state: State, target: State) -> State:
-        if (
-            self._machine.is_possible_action(state, target)
-            and self._quotas[target][index] > 0
-        ):
+    @property
+    def is_locked(self) -> bool:
+        return self._locked
+
+    def _recurse_state_hierarcy(
+        self, quotas: Dict[State, Quota], state: State, target: State
+    ) -> State:
+        if self._machine.is_possible_action(state, target) and quotas[target] > 0:
             return target
         return self._recurse_state_hierarcy(
-            index, *self._machine.next_possible_action(state, target)
+            quotas, *self._machine.next_possible_action(state, target)
         )
 
-    def _state_toggler(self, case: Case, target: State, index: int) -> None:
+    def _state_toggler(
+        self, case: Case, target: State, quotas: Dict[State, Quota]
+    ) -> None:
         history = self._history[case]
-        source = history[-1]
-        try:
-            state = self._recurse_state_hierarcy(index, source, target)
-        except RecursionError as e:
-            raise ValueError(
-                "A state lock was found in your configuration.\n"
-                f"current state map:\n{self._machine}\n"
-                "Please look to your state section and correct it as needed."
-            ) from e
-        self._quotas[state][index] -= 1
+        state = self._recurse_state_hierarcy(quotas, history[-1], target)
+        quotas[state] -= 1
         history.append(state)
 
     def process(
-        self, cases: Iterable[Case], target: State, index: int
-    ) -> Iterator[Tuple[Case, State]]:
-        """
-        Process given cases to target state.
-
-        If state target is not possible transition to the next possible state.
-
-        Parameters:
-        cases (Iterable[str]): The cases to be processed.
-        target (str): The target state to transition to.
-        index (int): The current iteration.
-
-        Returns:
-        Iterator[Tuple[str, str]]: An iterator yielding tuples of case and it's post-process state.
-        """
+        self, cases: Iterable[Case], target: State, quotas: Dict[State, Quota]
+    ) -> None:
         if not set(cases).issubset(self._history):
             raise ValueError("Case names must be a subset of initial state cases")
         for case in cases:
-            self._state_toggler(case, target, index)
-        return ((case, states[-1]) for case, states in self._history.items())
+            try:
+                self._state_toggler(case, target, quotas)
+            except RecursionError:
+                logger.warning(
+                    "Encounter a state lock:\n"
+                    f"{case = }\t"
+                    f"source = {self._history[case][-1]}\t{target = }\n"
+                    f"current state map:\n{self._machine}\n"
+                    f"state tree history:\n{self._history}\n"
+                    f"iteration quotas:\n{quotas}\n"
+                )
+                self._locked = True
+                break
+
+    def latest_valid_states(self, index: int) -> Iterator[Tuple[Case, State]]:
+        if not index and self._locked:
+            raise RuntimeError(
+                "A state lock was found on the first iteration.\n"
+                f"current state map:\n{self._machine}\n"
+                "Please check the states section in your configuration."
+            )
+        return (
+            (case, states[index - 1 if self._locked else -1])
+            for case, states in self._history.items()
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,10 @@ class TestSpec:
     def parse_forward_model_schema(self, path, schema):
         ...
 
+    @hookspec
+    def lint_forward_model(job, args):
+        ...
+
 
 class MockPluginManager(pluggy.PluginManager):
     """A testing plugin manager"""

--- a/tests/jobs/well_swapping/conftest.py
+++ b/tests/jobs/well_swapping/conftest.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 import pytest
-from everest_models.jobs.fm_well_swapping.models.state import Case, Quota, State
+from everest_models.jobs.fm_well_swapping.models import Case, Quota, State
 from everest_models.jobs.fm_well_swapping.state_machine import StateMachine
 from everest_models.jobs.fm_well_swapping.state_processor import StateProcessor
 
@@ -12,8 +12,8 @@ def well_swapping_initial_state() -> Dict[Case, State]:
 
 
 @pytest.fixture(scope="module")
-def well_swapping_quotas() -> Dict[State, List[Quota]]:
-    return {"open": [2, 2, 2, 2], "closed": [4, 4, 4, 4], "locked": [0, 0, 0, 0]}
+def well_swapping_quotas() -> Dict[State, Quota]:
+    return {"open": 2, "closed": 4, "locked": 0}
 
 
 @pytest.fixture(scope="module")
@@ -32,10 +32,8 @@ def well_swapping_state_machine(
 def well_swapping_state_processor(
     well_swapping_state_machine: StateMachine,
     well_swapping_initial_state: Dict[Case, State],
-    well_swapping_quotas: Dict[State, List[Quota]],
 ) -> StateProcessor:
     return StateProcessor(
         well_swapping_state_machine,
         well_swapping_initial_state,
-        well_swapping_quotas,
     )

--- a/tests/jobs/well_swapping/test_well_swapping_cli.py
+++ b/tests/jobs/well_swapping/test_well_swapping_cli.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 from everest_models.jobs.fm_well_swapping.cli import main_entry_point
@@ -8,21 +7,14 @@ from everest_models.jobs.shared.io_utils import load_json
 from sub_testdata import WELL_SWAPPING as TEST_DATA
 
 
-@pytest.mark.parametrize(
-    "command",
-    (
-        pytest.param(("run", "well_swap_config.yml"), id="command structure"),
-        pytest.param(("--config", "well_swap_config.yml"), id="legacy structure"),
-    ),
-)
-def test_well_swapping_main_entrypoint_run(
-    copy_testdata_tmpdir, command: Tuple[str]
-) -> None:
+def test_well_swapping_main_entrypoint_run(copy_testdata_tmpdir) -> None:
     copy_testdata_tmpdir(TEST_DATA)
     output = "well_swap_output.json"
     main_entry_point(
         (
-            *command,
+            "run",
+            "--config",
+            "well_swap_config.yml",
             "--priorities",
             "priorities.json",
             "--constraints",
@@ -40,7 +32,9 @@ def test_well_swapping_main_entrypoint_parse(copy_testdata_tmpdir) -> None:
     copy_testdata_tmpdir(TEST_DATA)
     files = tuple(Path().glob("*.*"))
     with pytest.raises(SystemExit, match="0"):
-        main_entry_point(("lint", "--cases", "wells.json", "well_swap_config.yml"))
+        main_entry_point(
+            ("lint", "--cases", "wells.json", "--config", "well_swap_config.yml")
+        )
     assert files == tuple(Path().glob("*.*"))
 
 
@@ -55,7 +49,9 @@ def test_well_swapping_main_entrypoint_parse_fault(
 
     files = tuple(Path().glob("*.*"))
     with pytest.raises(SystemExit, match="2"):
-        main_entry_point(("lint", "-p", "priorities.json", "well_swap_config.yml"))
+        main_entry_point(
+            ("lint", "-p", "priorities.json", "-c", "well_swap_config.yml")
+        )
 
     assert files == tuple(Path().glob("*.*"))
     _, err = capsys.readouterr()

--- a/tests/jobs/well_swapping/test_well_swapping_models.py
+++ b/tests/jobs/well_swapping/test_well_swapping_models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Tuple
 
 import pytest
 from everest_models.jobs.fm_well_swapping.models import StateConfig
@@ -59,16 +59,7 @@ def test_targets(input, expected, well_swap_state_hierarchy) -> None:
             {"hierarchy": well_swap_state_hierarchy, "targets": input}
         )
     )
-    assert state.get_targets(4, []) == expected
-
-
-def test_targets_error(well_swap_state_hierarchy) -> None:
-    assert (
-        state := StateConfig.model_validate({"hierarchy": well_swap_state_hierarchy})
-    )
-    errors: List[str] = []
-    state.get_targets(0, errors)
-    assert "Iteration must be greater than zero." in errors
+    assert state.get_targets(4) == expected
 
 
 @pytest.mark.parametrize(
@@ -108,7 +99,8 @@ def test_defualt_values(well_swap_state_hierarchy) -> None:
         state := StateConfig.model_validate({"hierarchy": well_swap_state_hierarchy})
     )
     assert state.get_initial(set("ABC")) == {"A": "low", "B": "low", "C": "low"}
-    assert state.get_targets(4, []) == ("high",) * 4
+    assert state.get_targets(4) == ("high",) * 4
+    assert list(state.get_quotas(4, 3)) == [{"low": 3, "middle": 3, "high": 3}] * 4
 
 
 @pytest.mark.parametrize(

--- a/tests/testdata/well_swapping/well_swap_config.yml
+++ b/tests/testdata/well_swapping/well_swap_config.yml
@@ -9,11 +9,11 @@ priorities:
   # Required: False
   # Default: null
   fallback_values:
-    WELL-1: [.5, .5, .5, .5]
-    WELL-2: [.5, .5, .5, .5]
-    WELL-3: [.5, .5, .5, .5]
-    WELL-4: [.5, .5, .5, .5]
-    WELL-5: [.5, .5, .5, .5]
+    WELL-1: [.51, .51, .5, .5]
+    WELL-2: [.5, .51, .51, .51]
+    WELL-3: [.51, .5, .51, .5]
+    WELL-4: [.51, .51, .51, .51]
+    WELL-5: [.51, .5, .5, .51]
 
 # Make sure the following are present in you Everest configuration file.
 

--- a/tests/testdata/workflows/well_swapping/well_swap_config.yml
+++ b/tests/testdata/workflows/well_swapping/well_swap_config.yml
@@ -9,11 +9,11 @@ priorities:
   # Required: False
   # Default: null
   fallback_values:
-    WELL-1: [.5, .5, .5, .5]
-    WELL-2: [.5, .5, .5, .5]
-    WELL-3: [.5, .5, .5, .5]
-    WELL-4: [.5, .5, .5, .5]
-    WELL-5: [.5, .5, .5, .5]
+    WELL-1: [.51, .51, .5, .5]
+    WELL-2: [.5, .51, .51, .51]
+    WELL-3: [.51, .5, .51, .5]
+    WELL-4: [.51, .51, .51, .51]
+    WELL-5: [.51, .5, .5, .51]
 
 # Make sure the following are present in you Everest configuration file.
 

--- a/tests/workflows/test_well_swapping_workflow.py
+++ b/tests/workflows/test_well_swapping_workflow.py
@@ -11,14 +11,15 @@ def test_well_swapping_workflow(copy_testdata_tmpdir) -> None:
     well_swapping(
         [
             "run",
+            "--config",
             "well_swap_config.yml",
-            "-p",
+            "--priorities",
             "priorities.json",
-            "-c",
+            "--constraints",
             "constraints.json",
-            "-o",
+            "--output",
             "well_swap_output.json",
-            "-cs",
+            "--cases",
             "wells.json",
         ]
     )


### PR DESCRIPTION
Well swapping exits when encountering a state lock That behaviour is now replace with a warning and on exit well swapping will return the latest valid state If unable to run any iteration, raise a state lock error with no valid state

Add a missing hook for new lint standard