### PR TITLE
Send in empty string for ResInsight binary if not configured

### DIFF
--- a/src/everest_models/jobs/fm_well_trajectory/well_trajectory_resinsight.py
+++ b/src/everest_models/jobs/fm_well_trajectory/well_trajectory_resinsight.py
@@ -22,7 +22,8 @@ class ResInsight:
     def __init__(self, executable: Optional[Path] = None) -> None:
         if executable is None:
             executable = shutil.which("ResInsight")
-        self._executable = executable
+        # ResInsight only checks for empty string and not None
+        self._executable = executable if executable is not None else ""
         signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
         signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
 


### PR DESCRIPTION
The following commit in `rips` allows for an external configuration file to specify the location of the ResInsight binary for a virtualenv: https://github.com/OPM/ResInsight/commit/84a07eed2b1739a225be5b1a0a1c73708751a8bc 
We want to use this in Komodo to avoid having the users setting `PYTHONPATH` and `RESINSIGHT_BINARY` environment variables in their config file, which often ends up mismatching with our komodo `rips` version. 

Issue after recent commit is that ´'None'´ is passed in to rips since in komodo you do not have ResInsight in path, and so rips does not look in the config file since it is not an empty value. See: https://github.com/equinor/komodo-releases/actions/runs/9596475383/job/26463913902

There is also the  issue of the current validation in everest-models, `fm_well_trajectory/cli.py`:
```
        if options.config.resinsight_binary is None:
            args_parser.error("missing ResInsight binary path")
```
In komodo we would want it to be valid with None value. How do we best resolve this? One option might be to allow it to be empty if one detects a komodo environment `KOMODO_RELEASE` environment variable exist. 

But might very well exist better solutions to the issues above? 

Related issue: https://github.com/equinor/everest-models/issues/9