### PR TITLE
Refactor read_trajectories allowing missing platform and/or kickoff

### DIFF
--- a/src/everest_models/jobs/fm_well_trajectory/models/config.py
+++ b/src/everest_models/jobs/fm_well_trajectory/models/config.py
@@ -1,6 +1,6 @@
 import datetime
 from pathlib import Path
-from typing import Literal, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 from pydantic import (
     AfterValidator,
@@ -83,7 +83,7 @@ class PlatformConfig(ModelConfig):
     x: Annotated[float, Field(description="")]
     y: Annotated[float, Field(description="")]
     z: Annotated[float, Field(default=0.0, description="")]
-    k: Annotated[float, Field(description="")]
+    k: Annotated[Optional[float], Field(default=None, description="")]
 
 
 class WellConfig(ModelConfig):

--- a/src/everest_models/jobs/fm_well_trajectory/resinsight.py
+++ b/src/everest_models/jobs/fm_well_trajectory/resinsight.py
@@ -25,13 +25,12 @@ def _create_perforation_view(
     perforations: Iterable[PerforationConfig],
     formations_file: Path,
     case: rips.Case,
-    wells: Iterable[str],
+    well_name: str,
 ) -> None:
-    for perforation in perforations:
-        if perforation.well in wells:
-            if perforation.formations:
-                case.import_formation_names([bytes(formations_file.resolve())])
-            case.create_view().set_time_step(-1)
+    perforation = next((item for item in perforations if item.well == well_name), None)
+    if perforation is not None and perforation.formations:
+        case.import_formation_names([bytes(formations_file.resolve())])
+    case.create_view().set_time_step(-1)
 
 
 def read_wells(
@@ -46,13 +45,15 @@ def read_wells(
         ],
         well_path_folder=str(well_path_folder),
     )
+
     if connection is not None:
-        _create_perforation_view(
-            connection.perforations,
-            connection.formations_file,
-            project.cases()[0],
-            well_names,
-        )
+        for well_name in well_names:
+            _create_perforation_view(
+                connection.perforations,
+                connection.formations_file,
+                project.cases()[0],
+                well_name,
+            )
 
     project.update()
 
@@ -68,13 +69,14 @@ def create_well(
     project: rips.Project,
     project_path: Path,
 ) -> rips.Project:
-    # ResInsight starts in a different directory we cannot use a relative path:
+    # ResInsight starts in a different directory, the project file must be absolute:
     project_file = project_path / "model.rsp"
 
-    targets = [
+    guide_points = [
         [str(x), str(y), str(z)]
         for x, y, z in zip(trajectory.x, trajectory.y, trajectory.z)
     ]
+    reference, targets = guide_points[0], guide_points[:1]
 
     _create_perforation_view(
         connection.perforations,
@@ -83,40 +85,21 @@ def create_well(
         well.name,
     )
 
-    # Add a new modeled well path
-    well_path_coll = project.descendants(rips.WellPathCollection)[0]
-    well_path = well_path_coll.add_new_object(rips.ModeledWellPath)
+    well_path_collection = project.descendants(rips.WellPathCollection)[0]
+    well_path = well_path_collection.add_new_object(rips.ModeledWellPath)
     well_path.name = well.name
     well_path.update()
 
-    # Create well targets
     intersection_points = []
     geometry = well_path.well_path_geometry()
 
-    # if the first point is already a platform:
-    if targets[0][2] == str(0.0):
-        # set first point as platform and remove from targets
-        reference = targets[0]
-        targets = targets[1:]
-    # otherwise, if platform and kickoff are inputs:
-    elif well.platform is not None:
-        platform = next(item for item in platforms if item.name == well.platform)
-        reference = [platform.x, platform.y, platform.z]
-        targets = [reference] + targets
-    # finally, when there is no platform info create platform directly above
-    # first guide point
-    else:
-        reference = [targets[0][0], targets[0][1], 0]
-
-    # Create reference point
     reference_point = geometry.reference_point
     reference_point[0] = reference[0]
     reference_point[1] = reference[1]
     reference_point[2] = reference[2]
     geometry.update()
 
-    for target in targets:
-        coord = target
+    for coord in targets:
         target = geometry.append_well_target(coordinate=coord, absolute=True)
         target.dogleg1 = well.dogleg
         target.dogleg2 = well.dogleg
@@ -124,14 +107,11 @@ def create_well(
         intersection_points.append(coord)
     geometry.update()
 
-    #### currently only available in resinsightdev
-    intersection_coll = project.descendants(rips.IntersectionCollection)[0]
-    # Add a CurveIntersection and set coordinates for the polyline
-    intersection = intersection_coll.add_new_object(rips.CurveIntersection)
+    intersection_collection = project.descendants(rips.IntersectionCollection)[0]
+    intersection = intersection_collection.add_new_object(rips.CurveIntersection)
     intersection.points = intersection_points
     intersection.update()
 
-    # Read out estimated dogleg and azimuth/inclination for well targets
     for well in geometry.well_path_targets():
         logger.info(
             "\t".join(
@@ -144,14 +124,13 @@ def create_well(
             )
         )
 
-    # Save the project to file
     logger.info(f"Saving project to: {project_file}")
     project.save(str(project_file))
     logger.info(
         f"Calling 'export_well_paths' on the resinsight project" f"\ncwd = {Path.cwd()}"
     )
-    # This log is deceving, it assumes that rips.Project().export_well_paths()
-    # exports the file to current workig dircetory (cwd) which is not true.
+    # This log is deceiving, it assumes that rips.Project().export_well_paths()
+    # exports the file to current working directory (cwd) which is not true.
     # pytest changes the working directory to '/tmp' but '.export_well_paths`
     # keeps exporting the file to the project root directory
     project.export_well_paths(well_paths=None, md_step_size=measured_depth_step)

--- a/tests/jobs/well_trajectory/test_well_trajectory.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory.py
@@ -1,0 +1,99 @@
+import copy
+from pathlib import Path
+
+import numpy as np
+import pytest
+from everest_models.jobs.fm_well_trajectory.models.config import ConfigSchema
+from everest_models.jobs.fm_well_trajectory.read_trajectories import read_trajectories
+from everest_models.jobs.shared.io_utils import load_yaml
+from sub_testdata import WELL_TRAJECTORY as TEST_DATA
+
+
+@pytest.fixture(scope="module")
+def well_trajectory_config(path_test_data):
+    return load_yaml(path_test_data / TEST_DATA / "config.yml")
+
+
+def test_read_trajectories(well_trajectory_config, copy_testdata_tmpdir):
+    copy_testdata_tmpdir(TEST_DATA)
+    config = ConfigSchema.model_validate(well_trajectory_config)
+
+    trajectories1 = read_trajectories(
+        config.scales, config.references, config.wells, config.platforms
+    )
+
+    for key in trajectories1:
+        for field in ["x", "y", "z"]:
+            assert len(getattr(trajectories1[key], field)) == 5
+        assert trajectories1[key].z[1] == 200
+
+
+def test_read_trajectories_platform_fallback(
+    well_trajectory_config, copy_testdata_tmpdir
+):
+    copy_testdata_tmpdir(TEST_DATA)
+    config = ConfigSchema.model_validate(well_trajectory_config)
+
+    Path("platform_k.json").unlink()
+
+    trajectories1 = read_trajectories(
+        config.scales, config.references, config.wells, config.platforms
+    )
+    for key in trajectories1:
+        for field in ["x", "y", "z"]:
+            assert len(getattr(trajectories1[key], field)) == 5
+        assert trajectories1[key].z[1] == 200
+
+
+def test_read_trajectories_no_platform(well_trajectory_config, copy_testdata_tmpdir):
+    copy_testdata_tmpdir(TEST_DATA)
+    config = ConfigSchema.model_validate(well_trajectory_config)
+
+    trajectories1 = read_trajectories(
+        config.scales, config.references, config.wells, config.platforms
+    )
+
+    Path("platform_k.json").unlink()
+
+    trajectories2 = read_trajectories(
+        config.scales, config.references, config.wells, []
+    )
+    for key in trajectories1:
+        for field in ["x", "y", "z"]:
+            assert np.all(
+                np.equal(
+                    getattr(trajectories1[key], field)[2:],
+                    getattr(trajectories2[key], field),
+                )
+            )
+
+
+def test_read_trajectories_no_kickof(well_trajectory_config, copy_testdata_tmpdir):
+    copy_testdata_tmpdir(TEST_DATA)
+    config = ConfigSchema.model_validate(well_trajectory_config)
+
+    trajectories1 = read_trajectories(
+        config.scales, config.references, config.wells, config.platforms
+    )
+
+    for key in trajectories1:
+        for field in ["x", "y", "z"]:
+            assert len(getattr(trajectories1[key], field)) == 5
+
+    Path("platform_k.json").unlink()
+
+    new_config = copy.deepcopy(well_trajectory_config)
+    del new_config["platforms"][0]["k"]
+    del new_config["platforms"][1]["k"]
+    config = ConfigSchema.model_validate(new_config)
+    trajectories2 = read_trajectories(
+        config.scales, config.references, config.wells, config.platforms
+    )
+    for key in trajectories1:
+        for field in ["x", "y", "z"]:
+            assert np.all(
+                np.equal(
+                    np.delete(getattr(trajectories1[key], field), 1),
+                    getattr(trajectories2[key], field),
+                )
+            )


### PR DESCRIPTION
This PR includes the following:
- A rewritten `read_trajectories `function that allows platforms and kickoffs to be missing to support optimization trajectories that do not have those
- Some refactoring off the `read_wells `and `create_wells ` functions that take the changes above into account and fixes minor bugs
- A test file for the new reading functionality
