### PR TITLE
Improve how resinsight executable is specified and detected

### DIFF
--- a/.github/workflows/test_resinsight.yml
+++ b/.github/workflows/test_resinsight.yml
@@ -84,13 +84,12 @@ jobs:
   tests:
     needs: build_dependencies
     if: ${{ always() && needs.build_dependencies.result != 'failed' }}
-    name: "tests_${{ matrix.os }}_py-${{ matrix.python-version }}_${{ matrix.test_type }}"
+    name: "tests_${{ matrix.os }}_py-${{ matrix.python-version }}_resinsight"
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.8]
         os: [ubuntu-22.04]
-        test_type: ["resinsight"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: "actions/setup-python@v5"
@@ -109,7 +108,6 @@ jobs:
           sudo apt -y install qtbase5-dev qtbase5-private-dev libqt5charts5-dev libqt5svg5-dev
           # Unpack after checking out, otherwise the checkout action would delete it:
           tar zxf resinsight_${{ env.RESINSIGHT_VERSION }}.tar.gz
-          echo "${{ github.workspace }}/${{ env.INSTALL_DIR }}" >> $GITHUB_PATH
       - name: "Install the package"
         run: |
           pip install --upgrade pip setuptools
@@ -118,4 +116,4 @@ jobs:
           pip install .[test]
       - name: Run tests using resinsight
         run: |
-          pytest -m "${{ matrix.test_type }}" -sv
+          RESINSIGHT_EXECUTABLE="${{ github.workspace }}/${{ env.INSTALL_DIR }}/ResInsight" pytest -sv --test-resinsight -m resinsight

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: "Test package everest-models"
         run: |
-          python -m pytest -sv -m "not resinsight" --hypothesis-profile ci
+          python -m pytest -sv --hypothesis-profile ci

--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -1,5 +1,5 @@
 
-install_package () {
+install_test_dependencies () {
     pip install .[test]
 }
 

--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -4,8 +4,5 @@ install_package () {
 }
 
 start_tests () {
-    # For unknown reasons the many_wells_one_ring hangs on Jenkins
-    python -m pytest \
-        -k "not test_many_wells_one_rig" \
-        --ignore="tests/unit/test_formatting.py"
+    python -m pytest --test-resinsight
 }

--- a/src/everest_models/jobs/fm_well_trajectory/cli.py
+++ b/src/everest_models/jobs/fm_well_trajectory/cli.py
@@ -41,8 +41,6 @@ def main_entry_point(args=None):
             eclipse_model := options.eclipse_model or options.config.eclipse_model
         ) is None:
             args_parser.error("missing eclipse model")
-        if options.config.resinsight_binary is None:
-            args_parser.error("missing ResInsight binary path")
         well_trajectory_resinsight(
             options.config,
             eclipse_model,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,9 +1,0 @@
-pytest
-decorator
-mock
-black
-hypothesis<=6.83.0;python_version=='3.8' # ipython pinned to 8.12.2 for python 3.8 support
-hypothesis;python_version>='3.9'
-pytest-runner
-pytest-timeout
-ruamel.yaml

--- a/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
@@ -7,13 +7,17 @@ from everest_models.jobs.fm_well_trajectory.well_trajectory_resinsight import Re
 @pytest.mark.resinsight
 def test_failing_start_resinsight(caplog):
     caplog.set_level(logging.INFO)
-    with pytest.raises(ConnectionError):
+    with pytest.raises(
+        ConnectionError,
+        match="Failed to launch ResInsight executable: _non_existing_binary_",
+    ):
         with ResInsight("_non_existing_binary_"):
             pass
     assert "Launching ResInsight..." in caplog.text
 
 
 @pytest.mark.resinsight
-def test_start_resinsight():
+def test_start_resinsight(caplog):
     with ResInsight() as ri:
         assert ri.project.cases() == []
+    assert "Launching ResInsight..." in caplog.text


### PR DESCRIPTION
This PR allows the ResInsight binary to be found via the `RESINSIGHT_EXECUTABLE`  environment variable, or from the configuration file in the `rips` installation.

Because tests that require ResInsight are slow and require a functional ResInsight, it might be better to not run them by default. This PR makes this more explicit by adding a cli option for pytest that is required to run those tests.
