### PR TITLE
Fix tests and typos

### DIFF
--- a/.github/workflows/test_resinsight.yml
+++ b/.github/workflows/test_resinsight.yml
@@ -15,11 +15,10 @@ env:
 
 jobs:
   build_dependencies:
-    name: "build-deps_${{ matrix.os }}_py-${{ matrix.python-version }}"
+    name: "build-deps_${{ matrix.os }}"
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
         os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
 
@@ -88,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: "Test package everest-models"
         run: |
-          python -m pytest -sv --hypothesis-profile ci
+          python -m pytest -sv --hypothesis-profile ci --run-slow

--- a/docs/reference/add_templates/config.yml
+++ b/docs/reference/add_templates/config.yml
@@ -9,7 +9,7 @@ templates:
 
     # File path to jinja template
     # Datatype: Path
-    # Examples: /path/to/file.ext, /path/to/dirictory/
+    # Examples: /path/to/file.ext, /path/to/directory/
     # Required: True
   file: '...'  # ← REPLACE
 

--- a/docs/reference/compute_economics/config.yml
+++ b/docs/reference/compute_economics/config.yml
@@ -154,12 +154,12 @@ well_costs:
 summary:
 
   # Datatype: Path
-  # Examples: /path/to/file.ext, /path/to/dirictory/
+  # Examples: /path/to/file.ext, /path/to/directory/
   # Required: True
   main: '...'  # ← REPLACE
 
   # Datatype: Path
-  # Examples: /path/to/file.ext, /path/to/dirictory/
+  # Examples: /path/to/file.ext, /path/to/directory/
   # Required: False
   # Default: null
   reference: null
@@ -170,7 +170,7 @@ summary:
   - '...'
 
 # Datatype: Path
-# Examples: /path/to/file.ext, /path/to/dirictory/
+# Examples: /path/to/file.ext, /path/to/directory/
 # Required: False
 # Default: null
 wells_input: null
@@ -180,7 +180,7 @@ wells_input: null
 output:
 
   # Datatype: Path
-  # Examples: /path/to/file.ext, /path/to/dirictory/
+  # Examples: /path/to/file.ext, /path/to/directory/
   # Required: True
   file: '...'  # ← REPLACE
 

--- a/docs/reference/well_swapping/well_swapping_config.yml
+++ b/docs/reference/well_swapping/well_swapping_config.yml
@@ -127,7 +127,7 @@ state:
   - '...'
 
   # Are cases allowed to stay at the same state?
-  # False: Inforce cases to change state each iteration, (can cause state lock)
+  # False: Enforce cases to change state each iteration, (can cause state lock)
   # True: Cases are allowed to stay at same state between iterations
 
   # Datatype: boolean
@@ -148,7 +148,7 @@ state:
 # Relative or absolute path to Everest generated or forward model modefied json case file.
 # NOTE: cli option argument `--cases CASES` overrides this field
 # Datatype: Path
-# Examples: /path/to/file.ext, /path/to/dirictory/
+# Examples: /path/to/file.ext, /path/to/directory/
 # Required: False
 # Default: null
 case_file: null

--- a/docs/reference/well_trajectory/config.yml
+++ b/docs/reference/well_trajectory/config.yml
@@ -71,7 +71,7 @@ connections:
   date: '...'  # ← REPLACE
 
   # Datatype: Path
-  # Examples: /path/to/file.ext, /path/to/dirictory/
+  # Examples: /path/to/file.ext, /path/to/directory/
   # Required: True
   formations_file: '...'  # ← REPLACE
 
@@ -223,31 +223,31 @@ outputs:
   save_paths: false
 
   # Datatype: Path
-  # Examples: /path/to/file.ext, /path/to/dirictory/
+  # Examples: /path/to/file.ext, /path/to/directory/
   # Required: False
   # Default: null
   guide_points: null
 
   # Datatype: Path
-  # Examples: /path/to/file.ext, /path/to/dirictory/
+  # Examples: /path/to/file.ext, /path/to/directory/
   # Required: False
   # Default: null
   geometry: null
 
   # Datatype: Path
-  # Examples: /path/to/file.ext, /path/to/dirictory/
+  # Examples: /path/to/file.ext, /path/to/directory/
   # Required: False
   # Default: null
   npv_input: null
 
 # Datatype: Path
-# Examples: /path/to/file.ext, /path/to/dirictory/
+# Examples: /path/to/file.ext, /path/to/directory/
 # Required: False
 # Default: null
 eclipse_model: null
 
 # Datatype: Path
-# Examples: /path/to/file.ext, /path/to/dirictory/
+# Examples: /path/to/file.ext, /path/to/directory/
 # Required: False
 # Default: null
 resinsight_binary: null

--- a/src/everest_models/jobs/fm_well_swapping/models/state.py
+++ b/src/everest_models/jobs/fm_well_swapping/models/state.py
@@ -178,7 +178,7 @@ class StateConfig(ModelConfig):
             default=True,
             description=(
                 "Are cases allowed to stay at the same state?\n"
-                "False: Inforce cases to change state each iteration, (can cause state lock)\n"
+                "False: Enforce cases to change state each iteration, (can cause state lock)\n"
                 "True: Cases are allowed to stay at same state between iterations\n"
             ),
         ),

--- a/src/everest_models/jobs/shared/models/base_config/introspective.py
+++ b/src/everest_models/jobs/shared/models/base_config/introspective.py
@@ -44,9 +44,15 @@ def builtin_datatypes(value: Any) -> str:
         except AttributeError:
             value = next(iter(value)).value
         return builtin_datatypes(value)
-    # check for nametuples
-    if is_related(value, Sequence) and hasattr(value, "_field_types"):
-        return str([builtin_datatypes(type_) for type_ in value._field_types.values()])
+    # check for namedtuples
+    if (
+        is_related(value, tuple)
+        and hasattr(value, "_asdict")
+        and hasattr(value, "__annotations__")
+    ):
+        return str(
+            [builtin_datatypes(type_) for type_ in value.__annotations__.values()]
+        )
     if origin := get_origin(value):
         if origin is Literal:
             return ", ".join(item for item in get_args(value))
@@ -76,7 +82,7 @@ def _example_types(value: Any) -> str:
     if is_related(value, str):
         return f"{prefix}: a string value"
     if is_related(value, Path):
-        return f"{prefix}: /path/to/file.ext, /path/to/dirictory/"
+        return f"{prefix}: /path/to/file.ext, /path/to/directory/"
     if is_related(value, date) or is_related(value, datetime):
         return f"{prefix}: 2024-01-31, 2024-01-31T11:06"
     if is_related(value, Enum):
@@ -119,12 +125,12 @@ def build_yaml_structure(data: Any, level: int = 0):
     This function recursively builds a commented YAML structure from CommentedObjects.
 
     It handles different types of containers, mappings, sequences, and CommentedObjects.
-    recursively break containers down to the essientials and and insert into yaml
+    recursively break containers down to the essentials and and insert into yaml
     container structure.
     For mappings, it creates a CommentedMap. If a value is a CommentedObject,
     For sequences, it creates a CommentedSeq. If an item is a CommentedObject,
     For standalone CommentedObject, extract elements (comments and value) from object
-    If the data is callable (default_factory), envoke it
+    If the data is callable (default_factory), evoke it
 
     Note: CommentedObject classes for handling comments in the YAML structure.
 
@@ -218,7 +224,7 @@ def parse_field_info(info: FieldInfo, minimal: bool, no_comment: bool) -> Any:
 
     no_comment (bool): A flag indicating whether comments should be included,
     False: will build comment string from parsed info data
-    and package the comment together with defualt value into a CommentedObject
+    and package the comment together with default value into a CommentedObject
     True: only default value is extracted
 
     Returns:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,9 +29,20 @@ def pytest_addoption(parser: Any) -> Any:
         default=False,
         help="Run ResInsight tests",
     )
+    parser.addoption(
+        "--run-slow",
+        action="store_true",
+        default=False,
+        help="Run slow tests",
+    )
 
 
 def pytest_collection_modifyitems(config: Any, items: Sequence[Any]) -> None:
+    if not config.getoption("--run-slow"):
+        skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
     if config.getoption("--test-resinsight"):
         instance = rips.Instance.launch(console=True)
         if instance is None:

--- a/tests/docs/test_reference_schemas.py
+++ b/tests/docs/test_reference_schemas.py
@@ -1,3 +1,4 @@
+import filecmp
 import importlib
 import sys
 from pathlib import Path
@@ -13,12 +14,8 @@ def test_doc_schemas(reference_docs: Path, tmp_path: Path):
     my_script = importlib.util.module_from_spec(spec)
     sys.modules["doc_schemas"] = my_script
     spec.loader.exec_module(my_script)
-
     my_script.main(["--output-directory", str(tmp_path)])
     assert any(tmp_path.iterdir())
-    assert (
-        temp.read_bytes() == docs.read_bytes()
-        for temp, docs in zip(
-            tmp_path.glob("**/*.yml"), reference_docs.glob("**/*.yml")
-        )
-    )
+    for doc in tmp_path.glob("**/*.yml"):
+        relative_path = doc.relative_to(tmp_path)
+        assert filecmp.cmp(reference_docs / relative_path, doc, shallow=False)

--- a/tests/jobs/shared/models/test_base_config.py
+++ b/tests/jobs/shared/models/test_base_config.py
@@ -78,7 +78,7 @@ class Wrapper(ModelConfig):
                 user_id: 213
 
                 # Datatype: Path
-                # Examples: /path/to/file.ext, /path/to/dirictory/
+                # Examples: /path/to/file.ext, /path/to/directory/
                 # Required: True
                 data: '...'  # ← REPLACE
                 """


### PR DESCRIPTION
PR to fix some bugs and tests regarding doc generation:
- Fix the test for doc generation (never failed).
- Fix generation of docs of nametuples (used an undocumented attribute).
- Fix various typos.
- Add a --run-slow option to the pytest code so that the slow doc generation tests is not run unnecessarily.
