### PR TITLE
Refactor the documentation generator and add doc strings for the well trajectory forward model

### DIFF
--- a/docs/reference/add_templates/config.yml
+++ b/docs/reference/add_templates/config.yml
@@ -1,19 +1,18 @@
 # -c/--config specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
 
-# Datatype: [Template map]
 # Required: True
 templates:
--
+  -
 
     # File path to jinja template
     # Datatype: Path
     # Examples: /path/to/file.ext, /path/to/directory/
     # Required: True
-  file: '...'  # ← REPLACE
+    file: <REPLACE>
 
     # Datatype: Keys
     # Examples: {opname: KBD, phase: WATER, <field>: <value>}
     # Required: False
-  keys: {}
+    keys: {}

--- a/docs/reference/compute_economics/config.yml
+++ b/docs/reference/compute_economics/config.yml
@@ -1,28 +1,27 @@
 # -c/--config specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
 
-# Datatype: {string: [CurrencyRate map]}
 # Required: True
 prices:
-  <string>:
-  -
+  <STRING>:
+    -
 
       # Datatype: number
       # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
       # Required: True
-    value: '...'  # ← REPLACE
+      value: <REPLACE>
 
       # Datatype: string
       # Examples: a string value
       # Required: False
       # Default: null
-    currency: null
+      currency: null
 
       # Datatype: date
       # Examples: 2024-01-31, 2024-01-31T11:06
       # Required: True
-    date: '...'  # ← REPLACE
+      date: <REPLACE>
 
 # Datatype: integer
 # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
@@ -42,7 +41,6 @@ default_exchange_rate: 1
 # Default: 0.08
 default_discount_rate: 0.08
 
-# Datatype: Dates map
 # Required: False
 dates:
 
@@ -64,99 +62,94 @@ dates:
   # Default: null
   ref_date: null
 
-# Datatype: {string: [CurrencyRate map]}
 # Required: False
 exchange_rates:
-  <string>:
-  -
+  <STRING>:
+    -
 
       # Datatype: number
       # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
       # Required: True
-    value: '...'  # ← REPLACE
+      value: <REPLACE>
 
       # Datatype: string
       # Examples: a string value
       # Required: False
       # Default: null
-    currency: null
+      currency: null
 
       # Datatype: date
       # Examples: 2024-01-31, 2024-01-31T11:06
       # Required: True
-    date: '...'  # ← REPLACE
+      date: <REPLACE>
 
-# Datatype: [CurrencyRate map]
 # Required: False
 discount_rates:
--
+  -
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: True
-  value: '...'  # ← REPLACE
+    value: <REPLACE>
 
     # Datatype: string
     # Examples: a string value
     # Required: False
     # Default: null
-  currency: null
+    currency: null
 
     # Datatype: date
     # Examples: 2024-01-31, 2024-01-31T11:06
     # Required: True
-  date: '...'  # ← REPLACE
+    date: <REPLACE>
 
-# Datatype: [CurrencyRate map]
 # Required: False
 costs:
--
+  -
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: True
-  value: '...'  # ← REPLACE
+    value: <REPLACE>
 
     # Datatype: string
     # Examples: a string value
     # Required: False
     # Default: null
-  currency: null
+    currency: null
 
     # Datatype: date
     # Examples: 2024-01-31, 2024-01-31T11:06
     # Required: True
-  date: '...'  # ← REPLACE
+    date: <REPLACE>
 
-# Datatype: [WellCost map]
 # Required: False
 well_costs:
--
+  -
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: True
-  value: '...'  # ← REPLACE
+    value: <REPLACE>
 
     # Datatype: string
     # Examples: a string value
     # Required: False
     # Default: null
-  currency: null
+    currency: null
 
     # Datatype: string
     # Examples: a string value
     # Required: True
-  well: '...' # ← REPLACE
+    well: <REPLACE>
 
-# Datatype: EclipseSummaryConfig map
 # Required: True
 summary:
 
   # Datatype: Path
   # Examples: /path/to/file.ext, /path/to/directory/
   # Required: True
-  main: '...'  # ← REPLACE
+  main: <REPLACE>
 
   # Datatype: Path
   # Examples: /path/to/file.ext, /path/to/directory/
@@ -167,7 +160,7 @@ summary:
   # Datatype: [string]
   # Required: False
   keys:
-  - '...'
+    - <REPLACE>
 
 # Datatype: Path
 # Examples: /path/to/file.ext, /path/to/directory/
@@ -175,14 +168,13 @@ summary:
 # Default: null
 wells_input: null
 
-# Datatype: OutputConfig map
 # Required: True
 output:
 
   # Datatype: Path
   # Examples: /path/to/file.ext, /path/to/directory/
   # Required: True
-  file: '...'  # ← REPLACE
+  file: <REPLACE>
 
   # Datatype: string
   # Examples: a string value
@@ -190,29 +182,27 @@ output:
   # Default: null
   currency: null
 
-  # Datatype: [CurrencyRate map]
   # Required: False
   # Default: null
   currency_rate:
-  -
+    -
 
       # Datatype: number
       # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
       # Required: True
-    value: '...'  # ← REPLACE
+      value: <REPLACE>
 
       # Datatype: string
       # Examples: a string value
       # Required: False
       # Default: null
-    currency: null
+      currency: null
 
       # Datatype: date
       # Examples: 2024-01-31, 2024-01-31T11:06
       # Required: True
-    date: '...'  # ← REPLACE
+      date: <REPLACE>
 
-# Datatype: OilEquivalentConversionConfig map
 # Required: False
 # Default: null
 oil_equivalent:
@@ -220,11 +210,11 @@ oil_equivalent:
   # Datatype: {string: number}
   # Required: True
   oil:
-    <string>: '...'
+    <STRING>: <REPLACE>
 
   # Datatype: {string: {string: number}}
   # Required: False
   # Default: null
   remap:
-    <string>:
-      <string>: '...'
+    <STRING>:
+      <STRING>: <REPLACE>

--- a/docs/reference/doc_schemas.py
+++ b/docs/reference/doc_schemas.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-import contextlib
 import os
 import pathlib
 import re
@@ -87,8 +86,11 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     args_parser = build_argument_parser()
     options = args_parser.parse_args(args)
     for job in forward_models(options.forward_models):
-        with contextlib.suppress(subprocess.CalledProcessError):
+        try:
             write_to_reference_docs(job, options.output_directory)
+        except subprocess.CalledProcessError as exc:
+            if "--schema" in " ".join(exc.cmd) and "usage:" in str(exc.output):
+                print(f"Skipping `{job}`: no schema generator implemented")
 
 
 if __name__ == "__main__":

--- a/docs/reference/drill_planner/config.yml
+++ b/docs/reference/drill_planner/config.yml
@@ -1,84 +1,80 @@
 # -c/--config specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
 
 # Datatype: date
 # Examples: 2024-01-31, 2024-01-31T11:06
 # Required: True
-start_date: '...'  # ← REPLACE
+start_date: <REPLACE>
 
 # Datatype: date
 # Examples: 2024-01-31, 2024-01-31T11:06
 # Required: True
-end_date: '...'  # ← REPLACE
+end_date: <REPLACE>
 
-# Datatype: [Rig map]
 # Required: True
 rigs:
--
+  -
 
     # Datatype: string
     # Examples: a string value
     # Required: True
-  name: '...'  # ← REPLACE
+    name: <REPLACE>
 
     # Datatype: [string]
     # Required: False
-  wells:
-  - '...'
+    wells:
+      - <REPLACE>
 
-    # Datatype: [Unavailability map]
     # Required: False
-  unavailability:
-  -
+    unavailability:
+      -
 
         # Datatype: date
         # Examples: 2024-01-31, 2024-01-31T11:06
         # Required: True
-    start: '...'  # ← REPLACE
+        start: <REPLACE>
 
         # Datatype: date
         # Examples: 2024-01-31, 2024-01-31T11:06
         # Required: True
-    stop: '...' # ← REPLACE
+        stop: <REPLACE>
 
     # Datatype: [string]
     # Required: False
-  slots:
-  - '...'
+    slots:
+      - <REPLACE>
 
     # Datatype: integer
-    # Examples: 1, 1.34E5, 1.34e5
+    # Examples: 1, 1.34E5
     # Required: False
     # Default: 0
-  delay: 0
+    delay: 0
 
-# Datatype: [Slot map]
 # Required: False
 slots:
--
+  -
 
     # Datatype: string
     # Examples: a string value
     # Required: True
-  name: '...'  # ← REPLACE
+    name: <REPLACE>
 
     # Datatype: [string]
     # Required: False
-  wells:
-  - '...'
+    wells:
+      - <REPLACE>
 
-    # Datatype: [Unavailability map]
     # Required: False
-  unavailability:
-  -
+    unavailability:
+      -
 
         # Datatype: date
         # Examples: 2024-01-31, 2024-01-31T11:06
         # Required: True
-    start: '...'  # ← REPLACE
+        start: <REPLACE>
 
         # Datatype: date
         # Examples: 2024-01-31, 2024-01-31T11:06
         # Required: True
-    stop: '...' # ← REPLACE
+        stop: <REPLACE>

--- a/docs/reference/npv/config.yml
+++ b/docs/reference/npv/config.yml
@@ -1,28 +1,27 @@
 # -c/--config specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
 
-# Datatype: {string: [CurrencyRate map]}
 # Required: True
 prices:
-  <string>:
-  -
+  <STRING>:
+    -
 
       # Datatype: number
       # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
       # Required: True
-    value: '...'  # ← REPLACE
+      value: <REPLACE>
 
       # Datatype: string
       # Examples: a string value
       # Required: False
       # Default: null
-    currency: null
+      currency: null
 
       # Datatype: date
       # Examples: 2024-01-31, 2024-01-31T11:06
       # Required: True
-    date: '...'  # ← REPLACE
+      date: <REPLACE>
 
 # Datatype: integer
 # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
@@ -42,7 +41,6 @@ default_exchange_rate: 1
 # Default: 0.08
 default_discount_rate: 0.08
 
-# Datatype: Dates map
 # Required: False
 dates:
 
@@ -64,92 +62,88 @@ dates:
   # Default: null
   ref_date: null
 
-# Datatype: {string: [CurrencyRate map]}
 # Required: False
 exchange_rates:
-  <string>:
-  -
+  <STRING>:
+    -
 
       # Datatype: number
       # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
       # Required: True
-    value: '...'  # ← REPLACE
+      value: <REPLACE>
 
       # Datatype: string
       # Examples: a string value
       # Required: False
       # Default: null
-    currency: null
+      currency: null
 
       # Datatype: date
       # Examples: 2024-01-31, 2024-01-31T11:06
       # Required: True
-    date: '...'  # ← REPLACE
+      date: <REPLACE>
 
-# Datatype: [CurrencyRate map]
 # Required: False
 discount_rates:
--
+  -
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: True
-  value: '...'  # ← REPLACE
+    value: <REPLACE>
 
     # Datatype: string
     # Examples: a string value
     # Required: False
     # Default: null
-  currency: null
+    currency: null
 
     # Datatype: date
     # Examples: 2024-01-31, 2024-01-31T11:06
     # Required: True
-  date: '...'  # ← REPLACE
+    date: <REPLACE>
 
-# Datatype: [CurrencyRate map]
 # Required: False
 costs:
--
+  -
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: True
-  value: '...'  # ← REPLACE
+    value: <REPLACE>
 
     # Datatype: string
     # Examples: a string value
     # Required: False
     # Default: null
-  currency: null
+    currency: null
 
     # Datatype: date
     # Examples: 2024-01-31, 2024-01-31T11:06
     # Required: True
-  date: '...'  # ← REPLACE
+    date: <REPLACE>
 
-# Datatype: [WellCost map]
 # Required: False
 well_costs:
--
+  -
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: True
-  value: '...'  # ← REPLACE
+    value: <REPLACE>
 
     # Datatype: string
     # Examples: a string value
     # Required: False
     # Default: null
-  currency: null
+    currency: null
 
     # Datatype: string
     # Examples: a string value
     # Required: True
-  well: '...' # ← REPLACE
+    well: <REPLACE>
 
 # Datatype: [string]
 # Required: True
 summary_keys:
-- '...'
+  - <REPLACE>

--- a/docs/reference/well_constraints/config.yml
+++ b/docs/reference/well_constraints/config.yml
@@ -1,10 +1,9 @@
 # -c/--config specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
-<string>:
-  <integer>:
+<STRING>:
+  <INTEGER>:
 
-    # Datatype: Phase map
     # Required: True
     phase:
 
@@ -12,7 +11,7 @@
       # Required: False
       # Default: null
       options:
-      - '...'
+        - <REPLACE>
 
       # Datatype: string
       # Choices: WATER, GAS, OIL
@@ -20,7 +19,6 @@
       # Default: null
       value: null
 
-    # Datatype: Tolerance map
     # Required: True
     rate:
 
@@ -42,7 +40,6 @@
       # Default: null
       value: null
 
-    # Datatype: Tolerance map
     # Required: True
     duration:
 

--- a/docs/reference/well_constraints/duration_constraints.yml
+++ b/docs/reference/well_constraints/duration_constraints.yml
@@ -1,5 +1,5 @@
 # -dc/--duration-constraints specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
-<string>:
-  <integer>: '...'
+<STRING>:
+  <INTEGER>: <REPLACE>

--- a/docs/reference/well_constraints/phase_constraints.yml
+++ b/docs/reference/well_constraints/phase_constraints.yml
@@ -1,5 +1,5 @@
 # -pc/--phase-constraints specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
-<string>:
-  <integer>: '...'
+<STRING>:
+  <INTEGER>: <REPLACE>

--- a/docs/reference/well_constraints/rate_constraints.yml
+++ b/docs/reference/well_constraints/rate_constraints.yml
@@ -1,5 +1,5 @@
 # -rc/--rate-constraints specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
-<string>:
-  <integer>: '...'
+<STRING>:
+  <INTEGER>: <REPLACE>

--- a/docs/reference/well_swapping/well_swapping_config.yml
+++ b/docs/reference/well_swapping/well_swapping_config.yml
@@ -1,9 +1,8 @@
 # -c/--config specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
 
 # Backup values for case priorities if priority JSON file is missing.
-# Datatype: Priorities map
 # Required: False
 # Default: null
 priorities:
@@ -13,8 +12,8 @@ priorities:
   # Required: False
   # Default: null
   fallback_values:
-    <string>:
-    - '...'
+    <STRING>:
+      - <REPLACE>
 
 
 # Make sure the following are present in you Everest configuration file.
@@ -30,12 +29,10 @@ priorities:
 #     variables:
 #     - { name: state_duration, initial_guess: [z0, z1, ..., zn] }
 
-# Datatype: Constraints map
 # Required: True
 constraints:
 
   # Constraint information for the time duration of any given state per iteraton
-  # Datatype: Constraint map
   # Required: True
   state_duration:
 
@@ -45,30 +42,28 @@ constraints:
     # Examples: [150, 200, 500], 200
     # Required: False
     # Default: null
-    fallback_values: '...'  # ← REPLACE
+    fallback_values: <REPLACE>
 
     # Scaling data used by everest for producing constraint files,
     # given these values this forward model will rescale the constraints
-    # Datatype: Scaling map
     # Required: True
     scaling:
 
       # [min, max] values for scaling source
       # Datatype: ['number', 'number']
       # Required: True
-      source: '...'  # ← REPLACE
+      source: <REPLACE>
 
       # [min, max] values for scaling target
       # Datatype: ['number', 'number']
       # Required: True
-      target: '...' # ← REPLACE
+      target: <REPLACE>
 
 # Datatype: date
 # Examples: 2024-01-31, 2024-01-31T11:06
 # Required: True
-start_date: '...' # ← REPLACE
+start_date: <REPLACE>
 
-# Datatype: StateConfig map
 # Required: True
 state:
 
@@ -76,16 +71,15 @@ state:
   # Note: values must be unique!
   # Tip: highest is the default target state
   # and lowest is the default initial state
-  # Datatype: [StateHierarchy map]
   # Required: True
   hierarchy:
-  -
+    -
 
       # State's label/name.
       # Datatype: string
       # Examples: a string value
       # Required: True
-    label: '...'  # ← REPLACE
+      label: <REPLACE>
 
       # Case state toggle quota per iteration.
       # Tip: '_', (infinity) alias can be used to pad array
@@ -95,7 +89,7 @@ state:
       # Examples: [_, 4, _, 2], 2
       # Required: False
       # Default: null
-    quotas: '...' # ← REPLACE
+      quotas: <REPLACE>
 
   # States to set cases to at initial iteration.
   # Tip: fill only cases that differ from default (lowest priority level in hierarchy),
@@ -105,7 +99,7 @@ state:
   # Datatype: {string: string} or string
   # Required: False
   # Default: null
-  initial: '...' # ← REPLACE
+  initial: <REPLACE>
 
   # Target States for each iteration.
   # Tip: '_', default alias can be used to pad array(highest priority level in hierarchy),
@@ -116,7 +110,7 @@ state:
   # Examples: _, sitting, _, standing], sitting
   # Required: False
   # Default: null
-  targets: '...' # ← REPLACE
+  targets: <REPLACE>
 
   # List of directional (source → target) state actions.
   # Note: action context is set with the 'forbiden_actions' field
@@ -124,7 +118,7 @@ state:
   # Required: False
   # Default: null
   actions:
-  - '...'
+    - <REPLACE>
 
   # Are cases allowed to stay at the same state?
   # False: Enforce cases to change state each iteration, (can cause state lock)

--- a/docs/reference/well_trajectory/config.yml
+++ b/docs/reference/well_trajectory/config.yml
@@ -2,72 +2,124 @@
 # <REPLACE> is a REQUIRED field that needs replacing
 
 
+# Scaling lengths for the guide points.
 # Required: True
 scales:
 
+  # Scaling length for coordinate x for the guide points.
   # Datatype: number
-  # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+  # Examples: 4000.0
   # Required: True
   x: <REPLACE>
 
+  # Scaling length for coordinate y for the guide points.
   # Datatype: number
-  # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+  # Examples: 4000.0
   # Required: True
   y: <REPLACE>
 
+  # Scaling length for coordinate z (positive depth) for the guide points.
   # Datatype: number
-  # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+  # Examples: 300.0
   # Required: True
   z: <REPLACE>
 
+  # Scaling length for z (positive depth) for the kick-off point.
   # Datatype: number
-  # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+  # Examples: 50.0
   # Required: False
   # Default: null
   k: null
 
+# Reference points for the guide points.
 # Required: True
 references:
 
+  # Coordinate x for reference point used in scaling of guide points.
   # Datatype: number
-  # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+  # Examples: 5000.0
   # Required: True
   x: <REPLACE>
 
+  # Coordinate y for reference point used in scaling of guide points.
   # Datatype: number
-  # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+  # Examples: 5000.0
   # Required: True
   y: <REPLACE>
 
+  # Coordinate z for reference point used in scaling of guide points.
   # Datatype: number
-  # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+  # Examples: 8375.0
   # Required: True
   z: <REPLACE>
 
+  # Coordinate z for reference point used in scaling of kick-off point.
   # Datatype: number
-  # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+  # Examples: 50.0
   # Required: False
   # Default: null
   k: null
 
+# Options related to interpolation of guide points.
 # Required: True
-interpolation: <REPLACE>
+interpolation:
 
+  # Interpolation type: 'simple' or 'resinsight'.
+  # Datatype: string
+  # Examples: resinsight
+  # Required: False
+  # Default: resinsight
+  type: resinsight
+
+  # Simple interpolation only.
+  # Datatype: integer
+  # Examples: 100
+  # Required: False
+  # Default: 50
+  length: 50
+
+  # Simple interpolation only.
+  # Datatype: integer
+  # Examples: 5000
+  # Required: False
+  # Default: 100000
+  trial_number: 100000
+
+  # Simple interpolation only.
+  # Datatype: number
+  # Examples: 0.02
+  # Required: False
+  # Default: 0.01
+  trial_step: 0.01
+
+  # ResInsight interpolation only: Step size used in exporting interpolated well trajectories.
+  # Datatype: integer
+  # Examples: 10
+  # Required: False
+  # Default: 5
+  measured_depth_step: 5
+
+# Options related to the connections.
 # Required: False
 # Default: null
 connections:
 
-  # Datatype: resinsight
-  # Required: True
-  type: <REPLACE>
+  # Connection type: currently only 'resinsight'.
+  # Datatype: string
+  # Examples: resinsight
+  # Required: False
+  # Default: resinsight
+  type: resinsight
 
+  # Simulation date used for grid perforation filtering based on time dynamic grid flow simulation data.
   # Datatype: date
   # Examples: 2024-01-31, 2024-01-31T11:06
   # Required: True
   date: <REPLACE>
 
+  # File defining list of grid based geological formations used for perforation filtering based on formations.
   # Datatype: Path
-  # Examples: /path/to/file.ext, /path/to/directory/
+  # Examples: /path/to/formations.lyr
   # Required: True
   formations_file: <REPLACE>
 
@@ -75,8 +127,9 @@ connections:
   perforations:
     -
 
+      # Well name.
       # Datatype: string
-      # Examples: a string value
+      # Examples: PRD1
       # Required: True
       well: <REPLACE>
 
@@ -84,18 +137,21 @@ connections:
       dynamic:
         -
 
+          # Keyword representing dynamic cell property in flow simulator which will be accepted in filtering.
           # Datatype: string
-          # Examples: a string value
+          # Examples: SOIL, SWAT
           # Required: True
           key: <REPLACE>
 
+          # Minimum value.
           # Datatype: number
-          # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+          # Examples: 0.5
           # Required: True
           min: <REPLACE>
 
+          # Maximum value.
           # Datatype: number
-          # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+          # Examples: 0.3
           # Required: True
           max: <REPLACE>
 
@@ -103,114 +159,135 @@ connections:
       static:
         -
 
+          # Keyword for static (initial) cell property in flow simulator which will be accepted in filtering.
           # Datatype: string
-          # Examples: a string value
+          # Examples: PORO, PERMX
           # Required: True
           key: <REPLACE>
 
+          # Minimum value.
           # Datatype: number
-          # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+          # Examples: 0.3, 100
           # Required: True
           min: <REPLACE>
 
+          # Maximum value.
           # Datatype: number
-          # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+          # Examples: 0.4, 30000
           # Required: True
           max: <REPLACE>
 
+      # List of indexes of formations (starting from 0) from formations file which will be accepted in filtering.
       # Datatype: [integer]
       # Required: False
       formations:
         - <REPLACE>
 
+# Configuration of the platforms.
 # Required: False
 platforms:
   -
 
+    # Name for platform.
     # Datatype: string
-    # Examples: a string value
+    # Examples: PLATF1
     # Required: True
     name: <REPLACE>
 
+    # Coordinate x of the platform at depth 0.
     # Datatype: number
-    # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+    # Examples: 5000.0
     # Required: True
     x: <REPLACE>
 
+    # Coordinate y of the platform at depth 0.
     # Datatype: number
-    # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+    # Examples: 5000.0
     # Required: True
     y: <REPLACE>
 
+    # Coordinate z of the kick-off (directly under the platform.)
     # Datatype: number
-    # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+    # Examples: 300.0
     # Required: False
     # Default: null
     k: null
 
+# Configuration of the wells.
 # Required: True
 wells:
   -
 
+    # Well name.
     # Datatype: string
-    # Examples: a string value
+    # Examples: PRD1
     # Required: True
     name: <REPLACE>
 
+    # Well group name to be assigned to well in flow simulator
     # Datatype: string
-    # Examples: a string value
+    # Examples: G1
     # Required: True
     group: <REPLACE>
 
+    # Well phase name to be assigned to well in flow simulator.
     # Datatype: string
-    # Choices: WATER, GAS, OIL
+    # Examples: WATER, OIL, GAS
     # Required: True
     phase: <REPLACE>
 
+    # Well skin value to be assigned to well in flow simulator.
     # Datatype: number
-    # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+    # Examples: 0.2
     # Required: False
     # Default: 0.0
     skin: 0.0
 
+    # Well radius value to be assigned to well in flow simulator.
     # Datatype: number
-    # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+    # Examples: 0.33
     # Required: False
     # Default: 0.15
     radius: 0.15
 
+    # Well maximum dogleg used for interpolating well trajectory.
     # Datatype: number
-    # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+    # Examples: 5.0
     # Required: False
     # Default: 4.0
     dogleg: 4.0
 
+    # Drilling cost per kilometer. Used to update well costs in the input file for NPV.
     # Datatype: number
-    # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+    # Examples: 4000000
     # Required: False
     # Default: 0.0
     cost: 0.0
 
+    # Name of the platform selected for the well.
     # Datatype: string
-    # Examples: a string value
+    # Examples: PLATF1
     # Required: False
     # Default: null
     platform: null
 
+# Path and name of the flow simulation grid model. Ignored if passed as argument instead.
 # Datatype: Path
-# Examples: /path/to/file.ext, /path/to/directory/
+# Examples: /path/to/MODEL.EGRID
 # Required: False
 # Default: null
 eclipse_model: null
 
+# Path to ResInsight executable. Defaults to system path.
 # Datatype: Path
-# Examples: /path/to/file.ext, /path/to/directory/
+# Examples: /path/to/ResInsight
 # Required: False
 # Default: null
 resinsight_binary: null
 
+# Path to YAML file (input to fm_npv) used to update the well costs.
 # Datatype: Path
-# Examples: /path/to/file.ext, /path/to/directory/
+# Examples: /path/to/npv_input.yml
 # Required: False
 # Default: null
 npv_input_file: null

--- a/docs/reference/well_trajectory/config.yml
+++ b/docs/reference/well_trajectory/config.yml
@@ -1,25 +1,24 @@
 # -c/--config specification:
-# '...' are REQUIRED fields that needs replacing
+# <REPLACE> is a REQUIRED field that needs replacing
 
 
-# Datatype: ScalesConfig map
 # Required: True
 scales:
 
   # Datatype: number
   # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
   # Required: True
-  x: '...'  # ← REPLACE
+  x: <REPLACE>
 
   # Datatype: number
   # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
   # Required: True
-  y: '...' # ← REPLACE
+  y: <REPLACE>
 
   # Datatype: number
   # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
   # Required: True
-  z: '...' # ← REPLACE
+  z: <REPLACE>
 
   # Datatype: number
   # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
@@ -27,24 +26,23 @@ scales:
   # Default: null
   k: null
 
-# Datatype: ReferencesConfig map
 # Required: True
 references:
 
   # Datatype: number
   # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
   # Required: True
-  x: '...'  # ← REPLACE
+  x: <REPLACE>
 
   # Datatype: number
   # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
   # Required: True
-  y: '...' # ← REPLACE
+  y: <REPLACE>
 
   # Datatype: number
   # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
   # Required: True
-  z: '...' # ← REPLACE
+  z: <REPLACE>
 
   # Datatype: number
   # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
@@ -52,159 +50,152 @@ references:
   # Default: null
   k: null
 
-# Datatype: SimpleInterpolationConfig map or ResInsightInterpolationConfig map
 # Required: True
-interpolation: '...'  # ← REPLACE
+interpolation: <REPLACE>
 
-# Datatype: ResInsightConnectionConfig map
 # Required: False
 # Default: null
 connections:
 
   # Datatype: resinsight
   # Required: True
-  type: '...'  # ← REPLACE
+  type: <REPLACE>
 
   # Datatype: date
   # Examples: 2024-01-31, 2024-01-31T11:06
   # Required: True
-  date: '...'  # ← REPLACE
+  date: <REPLACE>
 
   # Datatype: Path
   # Examples: /path/to/file.ext, /path/to/directory/
   # Required: True
-  formations_file: '...'  # ← REPLACE
+  formations_file: <REPLACE>
 
-  # Datatype: [PerforationConfig map]
   # Required: True
   perforations:
-  -
+    -
 
       # Datatype: string
       # Examples: a string value
       # Required: True
-    well: '...'  # ← REPLACE
+      well: <REPLACE>
 
-      # Datatype: [DomainProperty map]
       # Required: False
-    dynamic:
-    -
+      dynamic:
+        -
 
           # Datatype: string
           # Examples: a string value
           # Required: True
-      key: '...'  # ← REPLACE
+          key: <REPLACE>
 
           # Datatype: number
           # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
           # Required: True
-      min: '...' # ← REPLACE
+          min: <REPLACE>
 
           # Datatype: number
           # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
           # Required: True
-      max: '...' # ← REPLACE
+          max: <REPLACE>
 
-      # Datatype: [DomainProperty map]
       # Required: False
-    static:
-    -
+      static:
+        -
 
           # Datatype: string
           # Examples: a string value
           # Required: True
-      key: '...'  # ← REPLACE
+          key: <REPLACE>
 
           # Datatype: number
           # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
           # Required: True
-      min: '...' # ← REPLACE
+          min: <REPLACE>
 
           # Datatype: number
           # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
           # Required: True
-      max: '...' # ← REPLACE
+          max: <REPLACE>
 
       # Datatype: [integer]
       # Required: False
-    formations:
-    - '...'
+      formations:
+        - <REPLACE>
 
-# Datatype: [PlatformConfig map]
 # Required: False
 platforms:
--
+  -
 
     # Datatype: string
     # Examples: a string value
     # Required: True
-  name: '...'  # ← REPLACE
+    name: <REPLACE>
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: True
-  x: '...' # ← REPLACE
+    x: <REPLACE>
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: True
-  y: '...' # ← REPLACE
+    y: <REPLACE>
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: False
     # Default: null
-  k: null
+    k: null
 
-# Datatype: [WellConfig map]
 # Required: True
 wells:
--
+  -
 
     # Datatype: string
     # Examples: a string value
     # Required: True
-  name: '...'  # ← REPLACE
+    name: <REPLACE>
 
     # Datatype: string
     # Examples: a string value
     # Required: True
-  group: '...'  # ← REPLACE
+    group: <REPLACE>
 
     # Datatype: string
     # Choices: WATER, GAS, OIL
     # Required: True
-  phase: '...' # ← REPLACE
+    phase: <REPLACE>
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: False
     # Default: 0.0
-  skin: 0.0
+    skin: 0.0
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: False
     # Default: 0.15
-  radius: 0.15
+    radius: 0.15
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: False
     # Default: 4.0
-  dogleg: 4.0
+    dogleg: 4.0
 
     # Datatype: number
     # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
     # Required: False
     # Default: 0.0
-  cost: 0.0
+    cost: 0.0
 
     # Datatype: string
     # Examples: a string value
     # Required: False
     # Default: null
-  platform: null
+    platform: null
 
 # Datatype: Path
 # Examples: /path/to/file.ext, /path/to/directory/

--- a/src/everest_models/jobs/fm_well_trajectory/models/config.py
+++ b/src/everest_models/jobs/fm_well_trajectory/models/config.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import datetime
 from pathlib import Path
-from typing import Literal, Tuple, Union
+from typing import Tuple
 
 from pydantic import (
     AfterValidator,
@@ -10,6 +12,7 @@ from pydantic import (
     StringConstraints,
     ValidationInfo,
     field_validator,
+    model_validator,
 )
 from typing_extensions import Annotated
 
@@ -19,104 +22,383 @@ from everest_models.jobs.shared.validators import validate_eclipse_path
 
 
 class ScalesConfig(ModelConfig):
-    x: Annotated[float, Field(description="", gt=0)]
-    y: Annotated[float, Field(description="", gt=0)]
-    z: Annotated[float, Field(description="", gt=0)]
-    k: Annotated[float, Field(default=None, description="", gt=0)]
+    x: Annotated[
+        float,
+        Field(
+            description="Scaling length for coordinate x for the guide points.",
+            examples="4000.0",
+            gt=0,
+        ),
+    ]
+    y: Annotated[
+        float,
+        Field(
+            description="Scaling length for coordinate y for the guide points.",
+            examples="4000.0",
+            gt=0,
+        ),
+    ]
+    z: Annotated[
+        float,
+        Field(
+            description="Scaling length for coordinate z (positive depth) for the guide points.",
+            examples="300.0",
+            gt=0,
+        ),
+    ]
+    k: Annotated[
+        float,
+        Field(
+            default=None,
+            description="Scaling length for z (positive depth) for the kick-off point.",
+            examples="50.0",
+            gt=0,
+        ),
+    ]
 
 
 class ReferencesConfig(ModelConfig):
-    x: Annotated[float, Field(description="")]
-    y: Annotated[float, Field(description="")]
-    z: Annotated[float, Field(description="")]
-    k: Annotated[float, Field(default=None, description="")]
-
-
-class SimpleInterpolationConfig(ModelConfig):
-    type: Literal["simple"]
-    length: Annotated[int, Field(default=50, description="", gt=0)]
-    trial_number: Annotated[int, Field(default=100000, description="", ge=0)]
-    trial_step: Annotated[float, Field(default=0.01, description="", gt=0)]
-
-
-class ResInsightInterpolationConfig(ModelConfig):
-    type: Literal["resinsight"]
-    measured_depth_step: Annotated[float, Field(default=5, description="", gt=0)]
-
-
-class DomainProperty(ModelConfig):
-    key: Annotated[
-        str, StringConstraints(strip_whitespace=True, strict=True, pattern=r"^[^a-z]+$")
+    x: Annotated[
+        float,
+        Field(
+            description="Coordinate x for reference point used in scaling of guide points.",
+            examples="5000.0",
+        ),
     ]
-    min: Annotated[float, Field(description="")]
-    max: Annotated[float, Field(description="")]
+    y: Annotated[
+        float,
+        Field(
+            description="Coordinate y for reference point used in scaling of guide points.",
+            examples="5000.0",
+        ),
+    ]
+    z: Annotated[
+        float,
+        Field(
+            description="Coordinate z for reference point used in scaling of guide points.",
+            examples="8375.0",
+        ),
+    ]
+    k: Annotated[
+        float,
+        Field(
+            default=None,
+            description="Coordinate z for reference point used in scaling of kick-off point.",
+            examples="50.0",
+        ),
+    ]
+
+
+class InterpolationConfig(ModelConfig):
+    type: Annotated[
+        str,
+        Field(
+            default="resinsight",
+            description="Interpolation type: 'simple' or 'resinsight'.",
+            examples="resinsight",
+        ),
+    ]
+    length: Annotated[
+        int,
+        Field(
+            default=50,
+            description="Simple interpolation only.",
+            examples="100",
+            gt=0,
+        ),
+    ]
+    trial_number: Annotated[
+        int,
+        Field(
+            default=100000,
+            description="Simple interpolation only.",
+            examples="5000",
+            ge=0,
+        ),
+    ]
+    trial_step: Annotated[
+        float,
+        Field(
+            default=0.01,
+            description="Simple interpolation only.",
+            examples="0.02",
+            gt=0,
+        ),
+    ]
+    measured_depth_step: Annotated[
+        float,
+        Field(
+            default=5,
+            description="ResInsight interpolation only: Step size used in exporting interpolated well trajectories.",
+            examples="10",
+            gt=0,
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def check_type(self) -> InterpolationConfig:
+        fields_set = self.__pydantic_fields_set__ - {"type"}
+        if self.type == "resinsight":
+            fields = ["length", "trial_number", "trial_step"]
+            if fields_set & set(fields):
+                msg = f"Interpolation type 'resinsight': fields not allowed: {fields}"
+                raise ValueError(msg)
+        elif self.type == "simple":
+            if fields_set & {"measured_depth_step"}:
+                msg = "Interpolation type 'simple': 'measured_depth_step' not allowed"
+                raise ValueError(msg)
+        else:
+            msg = f"Unknown interpolation type: {self.type}"
+            raise ValueError(msg)
+        return self
+
+
+class DynamicDomainProperty(ModelConfig):
+    key: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, strict=True, pattern=r"^[^a-z]+$"),
+        Field(
+            description="Keyword representing dynamic cell property in flow simulator which will be accepted in filtering.",
+            examples="SOIL, SWAT",
+        ),
+    ]
+    min: Annotated[float, Field(description="Minimum value.", examples="0.5")]
+    max: Annotated[float, Field(description="Maximum value.", examples="0.3")]
+
+
+class StaticDomainProperty(ModelConfig):
+    key: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, strict=True, pattern=r"^[^a-z]+$"),
+        Field(
+            description="Keyword for static (initial) cell property in flow simulator which will be accepted in filtering.",
+            examples="PORO, PERMX",
+        ),
+    ]
+    min: Annotated[float, Field(description="Minimum value.", examples="0.3, 100")]
+    max: Annotated[float, Field(description="Maximum value.", examples="0.4, 30000")]
 
 
 class PerforationConfig(ModelConfig):
     well: Annotated[
-        str, StringConstraints(strip_whitespace=True, strict=True, pattern=r"^[^a-z]+$")
+        str,
+        StringConstraints(strip_whitespace=True, strict=True, pattern=r"^[^a-z]+$"),
+        Field(description="Well name.", examples="PRD1"),
     ]
     dynamic: Annotated[
-        Tuple[DomainProperty, ...],
+        Tuple[DynamicDomainProperty, ...],
         Field(default_factory=tuple, description=""),
     ]
     static: Annotated[
-        Tuple[DomainProperty, ...],
+        Tuple[StaticDomainProperty, ...],
         Field(default_factory=tuple, description=""),
     ]
-    formations: Annotated[Tuple[int, ...], Field(default_factory=tuple, description="")]
+    formations: Annotated[
+        Tuple[int, ...],
+        Field(
+            default_factory=tuple,
+            description="List of indexes of formations (starting from 0) from formations file which will be accepted in filtering.",
+        ),
+    ]
 
 
-class ResInsightConnectionConfig(ModelConfig):
-    type: Literal["resinsight"]
-    date: Annotated[datetime.date, Field(description="")]
+class ConnectionConfig(ModelConfig):
+    type: Annotated[
+        str,
+        Field(
+            default="resinsight",
+            description="Connection type: currently only 'resinsight'.",
+            examples="resinsight",
+        ),
+    ]
+    date: Annotated[
+        datetime.date,
+        Field(
+            description="Simulation date used for grid perforation filtering based on time dynamic grid flow simulation data."
+        ),
+    ]
     formations_file: Annotated[
         FilePath,
         PlainSerializer(path_to_str, when_used="unless-none"),
-        Field(description=""),
+        Field(
+            description="File defining list of grid based geological formations used for perforation filtering based on formations.",
+            examples="/path/to/formations.lyr",
+        ),
     ]
     perforations: Annotated[Tuple[PerforationConfig, ...], Field(description="")]
 
+    @model_validator(mode="after")
+    def check_type(self) -> ConnectionConfig:
+        if self.type != "resinsight":
+            msg = f"Unknown interpolation type: {self.type}"
+            raise ValueError(msg)
+        return self
+
 
 class PlatformConfig(ModelConfig):
-    name: str
-    x: Annotated[float, Field(description="")]
-    y: Annotated[float, Field(description="")]
-    k: Annotated[float, Field(default=None, description="")]
+    name: Annotated[
+        str,
+        Field(
+            description="Name for platform.",
+            examples="PLATF1",
+        ),
+    ]
+    x: Annotated[
+        float,
+        Field(
+            description="Coordinate x of the platform at depth 0.",
+            examples="5000.0",
+        ),
+    ]
+    y: Annotated[
+        float,
+        Field(
+            description="Coordinate y of the platform at depth 0.",
+            examples="5000.0",
+        ),
+    ]
+    k: Annotated[
+        float,
+        Field(
+            default=None,
+            description="Coordinate z of the kick-off (directly under the platform.)",
+            examples="300.0",
+        ),
+    ]
 
 
 class WellConfig(ModelConfig):
-    name: Annotated[str, Field(description="")]
-    group: Annotated[str, Field(description="")]
-    phase: Annotated[PhaseEnum, Field(description="")]
-    skin: Annotated[float, Field(default=0.0, description="", ge=0)]
-    radius: Annotated[float, Field(default=0.15, description="", gt=0)]
-    dogleg: Annotated[float, Field(default=4.0, description="", gt=0)]
-    cost: Annotated[float, Field(default=0.0, description="", ge=0)]
-    platform: Annotated[str, Field(default=None, description="")]
+    name: Annotated[
+        str,
+        Field(
+            description="Well name.",
+            examples="PRD1",
+        ),
+    ]
+    group: Annotated[
+        str,
+        Field(
+            description="Well group name to be assigned to well in flow simulator",
+            examples="G1",
+        ),
+    ]
+    phase: Annotated[
+        PhaseEnum,
+        Field(
+            description="Well phase name to be assigned to well in flow simulator.",
+            examples="WATER, OIL, GAS",
+        ),
+    ]
+    skin: Annotated[
+        float,
+        Field(
+            default=0.0,
+            description="Well skin value to be assigned to well in flow simulator.",
+            examples="0.2",
+            ge=0,
+        ),
+    ]
+    radius: Annotated[
+        float,
+        Field(
+            default=0.15,
+            description="Well radius value to be assigned to well in flow simulator.",
+            examples="0.33",
+            gt=0,
+        ),
+    ]
+    dogleg: Annotated[
+        float,
+        Field(
+            default=4.0,
+            description="Well maximum dogleg used for interpolating well trajectory.",
+            examples="5.0",
+            gt=0,
+        ),
+    ]
+    cost: Annotated[
+        float,
+        Field(
+            default=0.0,
+            description="Drilling cost per kilometer. Used to update well costs in the input file for NPV.",
+            examples="4000000",
+            ge=0,
+        ),
+    ]
+    platform: Annotated[
+        str,
+        Field(
+            default=None,
+            description="Name of the platform selected for the well.",
+            examples="PLATF1",
+        ),
+    ]
 
 
 class ConfigSchema(ModelConfig):
-    scales: Annotated[ScalesConfig, Field(description="")]
-    references: Annotated[ReferencesConfig, Field(description="")]
+    scales: Annotated[
+        ScalesConfig,
+        Field(
+            description="Scaling lengths for the guide points.",
+        ),
+    ]
+    references: Annotated[
+        ReferencesConfig,
+        Field(
+            description="Reference points for the guide points.",
+        ),
+    ]
     interpolation: Annotated[
-        Union[SimpleInterpolationConfig, ResInsightInterpolationConfig],
-        Field(description=""),
+        InterpolationConfig,
+        Field(
+            description="Options related to interpolation of guide points.",
+        ),
     ]
     connections: Annotated[
-        ResInsightConnectionConfig, Field(description="", default=None)
+        ConnectionConfig,
+        Field(
+            description="Options related to the connections.",
+            default=None,
+        ),
     ]
     platforms: Annotated[
-        Tuple[PlatformConfig, ...], Field(default_factory=tuple, description="")
+        Tuple[PlatformConfig, ...],
+        Field(
+            default_factory=tuple,
+            description="Configuration of the platforms.",
+        ),
     ]
-    wells: Annotated[Tuple[WellConfig, ...], Field(description="")]
+    wells: Annotated[
+        Tuple[WellConfig, ...],
+        Field(
+            description="Configuration of the wells.",
+        ),
+    ]
     eclipse_model: Annotated[
         Path,
         AfterValidator(validate_eclipse_path),
-        Field(description="", default=None),
+        Field(
+            description="Path and name of the flow simulation grid model. Ignored if passed as argument instead.",
+            examples="/path/to/MODEL.EGRID",
+            default=None,
+        ),
     ]
-    resinsight_binary: Annotated[FilePath, Field(default=None, description="")]
-    npv_input_file: Annotated[FilePath, Field(default=None, description="")]
+    resinsight_binary: Annotated[
+        FilePath,
+        Field(
+            default=None,
+            description="Path to ResInsight executable. Defaults to system path.",
+            examples="/path/to/ResInsight",
+        ),
+    ]
+    npv_input_file: Annotated[
+        FilePath,
+        Field(
+            default=None,
+            description="Path to YAML file (input to fm_npv) used to update the well costs.",
+            examples="/path/to/npv_input.yml",
+        ),
+    ]
 
     @field_validator("wells")
     def _validate_wells(

--- a/src/everest_models/jobs/fm_well_trajectory/resinsight.py
+++ b/src/everest_models/jobs/fm_well_trajectory/resinsight.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import lasio
 import pandas
@@ -10,9 +10,10 @@ import rips
 from everest_models.jobs.shared.models.phase import PhaseEnum
 
 from .models.config import (
-    DomainProperty,
+    ConnectionConfig,
+    DynamicDomainProperty,
     PerforationConfig,
-    ResInsightConnectionConfig,
+    StaticDomainProperty,
     WellConfig,
 )
 from .models.data_structs import Trajectory
@@ -36,7 +37,7 @@ def read_wells(
     project: rips.Project,
     well_path_folder: Path,
     well_names: Iterable[str],
-    connection: Optional[ResInsightConnectionConfig],
+    connection: Optional[ConnectionConfig],
 ) -> None:
     project.import_well_paths(
         well_path_files=[
@@ -58,7 +59,7 @@ def read_wells(
 
 
 def create_well(
-    connection: ResInsightConnectionConfig,
+    connection: ConnectionConfig,
     well_config: WellConfig,
     guide_points: Trajectory,
     project: rips.Project,
@@ -238,7 +239,7 @@ def create_well_logs(
 def _filter_properties(
     conditions: pandas.Series,
     df: pandas.DataFrame,
-    properties: Tuple[DomainProperty, ...],
+    properties: Tuple[Union[DynamicDomainProperty, StaticDomainProperty], ...],
 ) -> pandas.Series:
     for property in properties:
         if property.min is not None:

--- a/src/everest_models/jobs/fm_well_trajectory/well_trajectory_resinsight.py
+++ b/src/everest_models/jobs/fm_well_trajectory/well_trajectory_resinsight.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 
 import rips
 
-from .models.config import ConfigSchema, ResInsightInterpolationConfig
+from .models.config import ConfigSchema
 from .outputs import write_well_costs
 from .read_trajectories import read_laterals
 from .resinsight import (
@@ -75,7 +75,7 @@ def well_trajectory_resinsight(
     ) as resinsight:
         resinsight.project.load_case(str(eclipse_model.with_suffix(".EGRID")))
 
-        if isinstance(config.interpolation, ResInsightInterpolationConfig):
+        if config.interpolation.type == "resinsight":
             # Interpolate trajectories, keep the created well paths inc case we
             # will turn them into multi-lateral trajectories below:
             well_paths = {

--- a/src/everest_models/jobs/fm_well_trajectory/well_trajectory_simple.py
+++ b/src/everest_models/jobs/fm_well_trajectory/well_trajectory_simple.py
@@ -8,7 +8,7 @@ from numpy.typing import NDArray
 from .dogleg import compute_dogleg_severity, try_fixing_dog_leg
 from .geometry import compute_geometry
 from .interpolation import interpolate_points
-from .models.config import SimpleInterpolationConfig, WellConfig
+from .models.config import InterpolationConfig, WellConfig
 from .models.data_structs import CalculatedTrajectory, Trajectory
 from .outputs import write_path_files, write_resinsight, write_well_costs, write_wicalc
 from .well_costs import compute_well_costs
@@ -35,7 +35,7 @@ def _check_kickoff_alignment(
 
 def _generate_coordinates_dogleg(
     wells: Iterable[WellConfig],
-    interpolation: SimpleInterpolationConfig,
+    interpolation: InterpolationConfig,
     trajectories: Dict[str, Trajectory],
 ) -> Iterator[Tuple[str, Trajectory, NDArray[numpy.float64]]]:
     for well in wells:
@@ -57,7 +57,7 @@ def _generate_coordinates_dogleg(
 
 def _compute_well_trajectory(
     wells: Iterable[WellConfig],
-    interpolation: SimpleInterpolationConfig,
+    interpolation: InterpolationConfig,
     trajectories: Dict[str, Trajectory],
 ) -> Dict[str, CalculatedTrajectory]:
     _check_kickoff_alignment(wells, trajectories)
@@ -71,7 +71,7 @@ def _compute_well_trajectory(
 
 def well_trajectory_simple(
     wells: Iterable[WellConfig],
-    interpolation: SimpleInterpolationConfig,
+    interpolation: InterpolationConfig,
     npv_input_file: Optional[pathlib.Path],
     guide_points: Dict[str, Trajectory],
 ) -> None:

--- a/src/everest_models/jobs/shared/io_utils.py
+++ b/src/everest_models/jobs/shared/io_utils.py
@@ -55,5 +55,5 @@ def dump_yaml(
     _yaml.representer.add_representer(
         type(None), lambda x, _: x.represent_scalar("tag:yaml.org,2002:null", "null")
     )
-    _yaml.indent(mapping=2, sequence=2, offset=0)
+    _yaml.indent(mapping=2, sequence=4, offset=2)
     _yaml.dump(data, fp)

--- a/src/everest_models/jobs/shared/parsers/action.py
+++ b/src/everest_models/jobs/shared/parsers/action.py
@@ -16,6 +16,7 @@ from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from .. import is_related
 from ..io_utils import dump_yaml
 from ..models import Model, ModelConfig, Wells
+from ..models.base_config.introspective import PLACEHOLDER
 
 
 def _get_filepath(base_name: str, no_overwrite: bool, minimal: bool) -> Path:
@@ -28,7 +29,7 @@ def _get_filepath(base_name: str, no_overwrite: bool, minimal: bool) -> Path:
     )
 
 
-def _model_specsifactions(
+def _model_specificactions(
     argument: str, model: ModelConfig, minimal: bool, no_comment: bool
 ) -> Union[Dict[str, Any], CommentedSeq, CommentedMap]:
     if no_comment:
@@ -36,7 +37,7 @@ def _model_specsifactions(
 
     data = model.commented_map(minimal)
     data.yaml_set_start_comment(
-        f"{argument} specification:\n'...' are REQUIRED fields that needs replacing\n\n"
+        f"{argument} specification:\n{PLACEHOLDER} is a REQUIRED field that needs replacing\n\n"
     )
     return data
 
@@ -55,7 +56,7 @@ class SchemaAction(Action):
             (
                 argument.split("/")[-1].lstrip("-"),
                 model,
-                _model_specsifactions(argument, model, minimal, no_comment),
+                _model_specificactions(argument, model, minimal, no_comment),
             )
             for argument, model in self._models.items()
         )

--- a/tests/jobs/shared/models/test_base_config.py
+++ b/tests/jobs/shared/models/test_base_config.py
@@ -47,7 +47,6 @@ class Wrapper(ModelConfig):
             dedent(
                 """
                 # User description. A relatively simple data.
-                # Datatype: User map
                 # Required: True
                 user:
 
@@ -62,7 +61,7 @@ class Wrapper(ModelConfig):
                   # Datatype: integer
                   # Examples: 5, 1.5e4
                   # Required: True
-                  age: '...'  # ← REPLACE
+                  age: <REPLACE>
 
                   # Sex of the user
                   # Datatype: string
@@ -72,7 +71,7 @@ class Wrapper(ModelConfig):
                   sex: male
 
                 # Datatype: integer
-                # Examples: 1, 1.34E5, 1.34e5
+                # Examples: 1, 1.34E5
                 # Required: False
                 # Default: 213
                 user_id: 213
@@ -80,7 +79,7 @@ class Wrapper(ModelConfig):
                 # Datatype: Path
                 # Examples: /path/to/file.ext, /path/to/directory/
                 # Required: True
-                data: '...'  # ← REPLACE
+                data: <REPLACE>
                 """
             ),
             id="wrapper over user",
@@ -102,7 +101,7 @@ class Wrapper(ModelConfig):
                   # Datatype: integer
                   # Examples: 5, 1.5e4
                   # Required: True
-                  age: '...'  # ← REPLACE
+                  age: <REPLACE>
 
                   # Sex of the user
                   # Datatype: string
@@ -118,8 +117,8 @@ class Wrapper(ModelConfig):
             DeepNested,
             dedent(
                 """\
-                <string>:
-                  <integer>:
+                <STRING>:
+                  <INTEGER>:
 
                     # The name of the test model
                     # Datatype: string
@@ -132,7 +131,7 @@ class Wrapper(ModelConfig):
                     # Datatype: integer
                     # Examples: 5, 1.5e4
                     # Required: True
-                    age: '...'  # ← REPLACE
+                    age: <REPLACE>
 
                     # Sex of the user
                     # Datatype: string

--- a/tests/jobs/shared/models/test_introspective.py
+++ b/tests/jobs/shared/models/test_introspective.py
@@ -18,7 +18,7 @@ from ruamel.yaml import YAML
 @pytest.fixture(scope="package")
 def yaml() -> YAML:
     _yaml = YAML()
-    _yaml.indent(mapping=2, sequence=2, offset=0)
+    _yaml.indent(mapping=2, sequence=4, offset=2)
     return _yaml
 
 
@@ -53,14 +53,17 @@ def yaml() -> YAML:
             id="nested mapping",
         ),
         pytest.param(
-            [
-                CommentedObject(1, inline_comment="First item"),
-                CommentedObject(2, "Second item"),
-            ],
+            {
+                "inline": [
+                    CommentedObject(1, inline_comment="First item"),
+                    CommentedObject(2, "Second item"),
+                ]
+            },
             dedent(
                 """\
-                - 1  # First item
-                - 2
+                inline:
+                  - 1  # First item
+                  - 2
                 """
             ),
             id="sequence",
@@ -71,7 +74,7 @@ def yaml() -> YAML:
                 """\
                 # List item comment
                 list:
-                - dict_in_list: true
+                  - dict_in_list: true
                 """
             ),
             id="mixed data",
@@ -96,12 +99,12 @@ def yaml() -> YAML:
                 """\
                 # List item comment
                 list:
-                - string_a:
-                  - true
-                  - false
+                  - string_a:
+                      - true
+                      - false
                     # string_b comment
-                  string_b:  # TODO: I will not do it
-                    string_x: 0.5
+                    string_b:  # TODO: I will not do it
+                      string_x: 0.5
                 """
             ),
             id="deeply nested",
@@ -138,7 +141,7 @@ def test_builtin_datatypes_with_base_model():
     class MyModel(BaseModel):
         pass
 
-    assert builtin_datatypes(MyModel) == "MyModel map"
+    assert builtin_datatypes(MyModel) == "__remove__"
 
 
 def test_builtin_datatypes_with_enum():

--- a/tests/jobs/well_trajectory/test_well_trajectory_models.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_models.py
@@ -1,10 +1,28 @@
 from pathlib import Path
 
 import pytest
-from everest_models.jobs.fm_well_trajectory.models.config import ConfigSchema
+from everest_models.jobs.fm_well_trajectory.models.config import (
+    ConfigSchema,
+    InterpolationConfig,
+)
 from everest_models.jobs.shared.io_utils import load_yaml
 from pydantic import ValidationError
 from sub_testdata import WELL_TRAJECTORY as TEST_DATA
+
+
+def test_interpolation_config():
+    with pytest.raises(
+        ValidationError,
+        match=r"Interpolation type 'simple': 'measured_depth_step' not allowed",
+    ):
+        InterpolationConfig.model_validate({"type": "simple", "measured_depth_step": 1})
+    with pytest.raises(
+        ValidationError,
+        match=r"Interpolation type 'resinsight': fields not allowed: \['length', 'trial_number', 'trial_step'\]",
+    ):
+        InterpolationConfig.model_validate(
+            {"type": "resinsight", "length": 1, "trial_step": 0.1}
+        )
 
 
 def test_parameters_config_simple(path_test_data):


### PR DESCRIPTION
This PR finalizes the multi-lateral well trajectory forward model.

The first commit updates the documentation generator to refine its output and make it a bit more resilient to errors.

The second commit refactors the input config of the mlt foward model slightly. It drops some more advanced pydantic features in favor of a simpler approach since the doc generator could not handle the config properly. It also adds documentation strings for the mlt forward model

closes #10 