### PR TITLE
Cleanup underscore zeros from output files in stea and npv jobs

### DIFF
--- a/src/everest_models/jobs/fm_npv/cli.py
+++ b/src/everest_models/jobs/fm_npv/cli.py
@@ -26,6 +26,12 @@ def main_entry_point(args=None):
             "must always be paired; one of the two is missing."
         )
 
+    if args and "-o" not in args and "--output" not in args:
+        logger.warning(
+            "Objective names ending in '_0' have been deprecated by everest! "
+            "Replace objective `npv_0` with `npv` in the everest config file."
+        )
+
     if options.lint:
         args_parser.exit()
 

--- a/src/everest_models/jobs/fm_npv/parser.py
+++ b/src/everest_models/jobs/fm_npv/parser.py
@@ -36,7 +36,7 @@ def build_argument_parser():
     add_output_argument(
         parser,
         required=False,
-        default="npv_0",
+        default="npv",
         help="Path to output-file where the NPV result is written to.",
     )
     required_group.add_argument(

--- a/src/everest_models/jobs/fm_stea/cli.py
+++ b/src/everest_models/jobs/fm_stea/cli.py
@@ -18,7 +18,7 @@ def main_entry_point(args=None):
     for res, value in (
         stea.calculate(options.config).results(stea.SteaKeys.CORPORATE).items()
     ):
-        with open(f"{res}_0", "w") as ofh:
+        with open(f"{res}", "w") as ofh:
             ofh.write(f"{value}\n")
 
 

--- a/src/everest_models/jobs/fm_stea/parser.py
+++ b/src/everest_models/jobs/fm_stea/parser.py
@@ -12,7 +12,7 @@ def build_argument_parser():
         "projects, large and small portfolios and complex decision trees. "
         "As output, for each of the entries in the result section of the "
         "yaml config file, STEA will create result files "
-        "ex: Res1_0, Res2_0, .. Res#_0"
+        "ex: Res1, Res2, .. Res#"
     )
     parser, required_group = get_parser(description=description)
     add_lint_argument(parser)

--- a/tests/jobs/compute_economics/parser.py
+++ b/tests/jobs/compute_economics/parser.py
@@ -130,7 +130,7 @@ class Options(NamedTuple):
     multiplier: Optional[float] = 1.0
     schema: Optional[bool] = None
     lint: Optional[bool] = None
-    output: pathlib.Path = pathlib.Path("test_0")
+    output: pathlib.Path = pathlib.Path("test")
     output_currency: Optional[str] = None
 
 

--- a/tests/jobs/compute_economics/test_compute_economics_cli.py
+++ b/tests/jobs/compute_economics/test_compute_economics_cli.py
@@ -52,7 +52,7 @@ def test_economic_indicator_main_entry_point(
     )
 
     cli.main_entry_point()
-    assert pathlib.Path("test_0").read_text() == expected
+    assert pathlib.Path("test").read_text() == expected
 
 
 @pytest.mark.parametrize(
@@ -71,7 +71,7 @@ def test_economic_indicator_main_entry_point_npv_output_currency_USD(
     )
 
     cli.main_entry_point()
-    assert pathlib.Path("test_0").read_text() == "77942465.48"
+    assert pathlib.Path("test").read_text() == "77942465.48"
 
 
 @pytest.mark.parametrize(
@@ -131,7 +131,7 @@ def test_economic_indicator_main_entry_point_no_input(
     )
 
     cli.main_entry_point()
-    assert pathlib.Path("test_0").read_text() == expected
+    assert pathlib.Path("test").read_text() == expected
 
 
 @pytest.mark.parametrize(
@@ -186,4 +186,4 @@ def test_bep_main_entry_lint_ignore_overwrite_config(
         cli.main_entry_point()
     assert e.value.code == 0
     assert "Overwrite config field with 'multiplier' CLI argument" not in caplog.text
-    assert not pathlib.Path("test_0").exists()
+    assert not pathlib.Path("test").exists()

--- a/tests/jobs/compute_economics/test_compute_economics_config_model.py
+++ b/tests/jobs/compute_economics/test_compute_economics_config_model.py
@@ -26,7 +26,7 @@ def test_economic_indicator_config_defaults():
                 },
                 {"date": "1999-10-01", "value": 20000000},
             ],
-            "output": {"file": "test_0", "currency": "USD"},
+            "output": {"file": "test", "currency": "USD"},
         }
     )
 
@@ -40,5 +40,5 @@ def test_economic_indicator_config_defaults():
     assert not config.discount_rates and isinstance(config.discount_rates, tuple)
     assert not config.well_costs and isinstance(config.well_costs, tuple)
     assert isinstance(config.output, OutputConfig)
-    assert config.output.file == pathlib.Path("test_0")
+    assert config.output.file == pathlib.Path("test")
     assert config.output.currency == "USD"

--- a/tests/jobs/npv/parser.py
+++ b/tests/jobs/npv/parser.py
@@ -54,7 +54,7 @@ class Options(NamedTuple):
     lint: Optional[bool] = None
     multiplier: float = 1.0
     summary: Summary = ecl_summary_npv()
-    output: pathlib.Path = pathlib.Path("test_0")
+    output: pathlib.Path = pathlib.Path("test")
 
 
 class MockParser:

--- a/tests/jobs/npv/test_npv_cli.py
+++ b/tests/jobs/npv/test_npv_cli.py
@@ -35,7 +35,7 @@ def test_npv_main_entry_point(copy_testdata_tmpdir, monkeypatch, input_file):
         ),
     )
     cli.main_entry_point()
-    assert pathlib.Path("test_0").read_text() == "691981114.68"
+    assert pathlib.Path("test").read_text() == "691981114.68"
 
 
 def test_npv_main_entry_point_no_input_error(copy_testdata_tmpdir, monkeypatch, capsys):
@@ -92,7 +92,7 @@ def test_npv_main_entry_point_no_input(copy_testdata_tmpdir, monkeypatch):
         ),
     )
     cli.main_entry_point()
-    assert pathlib.Path("test_0").read_text() == "865092178.90"
+    assert pathlib.Path("test").read_text() == "865092178.90"
 
 
 @pytest.mark.parametrize(
@@ -147,4 +147,4 @@ def test_npv_main_entry_lint_ignore_overwrite_config(
         cli.main_entry_point()
     assert e.value.code == 0
     assert "Overwrite config field with 'multiplier' CLI argument" not in caplog.text
-    assert not pathlib.Path("test_0").exists()
+    assert not pathlib.Path("test").exists()

--- a/tests/jobs/npv/test_npv_cli.py
+++ b/tests/jobs/npv/test_npv_cli.py
@@ -3,10 +3,10 @@ import logging
 import pathlib
 
 import pytest
-from jobs.npv.parser import MockParser, Options
+from jobs.npv.parser import MockParser, Options, ecl_summary_npv
 from sub_testdata import NPV as TEST_DATA
 
-from everest_models.jobs.fm_npv import cli
+from everest_models.jobs.fm_npv import cli, parser
 from everest_models.jobs.fm_npv.npv_config import NPVConfig
 from everest_models.jobs.shared.models import Wells
 from everest_models.jobs.shared.validators import parse_file
@@ -148,3 +148,37 @@ def test_npv_main_entry_lint_ignore_overwrite_config(
     assert e.value.code == 0
     assert "Overwrite config field with 'multiplier' CLI argument" not in caplog.text
     assert not pathlib.Path("test").exists()
+
+
+def test_npv_main_entry_point_warning_for_default_output(
+    copy_testdata_tmpdir, monkeypatch, caplog
+):
+    copy_testdata_tmpdir(TEST_DATA)
+    monkeypatch.setattr(
+        parser,
+        "add_summary_argument",
+        lambda p: p.add_argument("--summary", default=ecl_summary_npv()),
+    )
+    args = ["-i", "wells.json", "-c", _CONFIG_FILE]
+    cli.main_entry_point(args)
+    assert (
+        "Objective names ending in '_0' have been deprecated by everest! "
+        "Replace objective `npv_0` with `npv` in the everest config file."
+    ) in caplog.text
+    assert pathlib.Path("npv").exists()
+
+
+@pytest.mark.parametrize("output_arg", ("-o", "--output"))
+def test_npv_main_entry_point_no_warning_for_non_default_output(
+    copy_testdata_tmpdir, monkeypatch, caplog, output_arg
+):
+    copy_testdata_tmpdir(TEST_DATA)
+    monkeypatch.setattr(
+        parser,
+        "add_summary_argument",
+        lambda p: p.add_argument("--summary", default=ecl_summary_npv()),
+    )
+    args = ["-i", "wells.json", "-c", _CONFIG_FILE, output_arg, "npv_test"]
+    cli.main_entry_point(args)
+    assert "Objective names ending in '_0' have been deprecated" not in caplog.text
+    assert pathlib.Path("npv_test").exists()

--- a/tests/jobs/stea/test_stea_cli.py
+++ b/tests/jobs/stea/test_stea_cli.py
@@ -36,7 +36,7 @@ def test_stea(copy_testdata_tmpdir, stea_args, monkeypatch):
     # run stea job
     main_entry_point(stea_args)
     files = os.listdir(os.getcwd())
-    assert "NPV_0" in files
+    assert "NPV" in files
 
 
 def test_stea_lint(copy_testdata_tmpdir, stea_args):

--- a/tests/testdata/compute_economics/input_data.yml
+++ b/tests/testdata/compute_economics/input_data.yml
@@ -66,4 +66,4 @@ oil_equivalent:
       FW2PT: 3.0
 
 output:
-  file: test_0
+  file: test


### PR DESCRIPTION
Everest no longer requires _0 for objective function names.

Closes #52