### PR TITLE
Replace forward model step output validation with args validation

### DIFF
--- a/src/everest_models/everest_hooks.py
+++ b/src/everest_models/everest_hooks.py
@@ -9,11 +9,10 @@ import logging
 import pathlib
 from importlib import import_module
 from importlib.resources import files
-from typing import Any, Dict, List, Sequence, Set, Type
+from typing import Any, Dict, List, Sequence, Type
 
 from pydantic import BaseModel
 
-from everest_models.forward_models import get_forward_models
 from everest_models.jobs.shared.io_utils import load_supported_file_encoding
 
 try:
@@ -109,21 +108,3 @@ def get_forward_model_documentations() -> Dict[str, Any]:
             "full_job_name": full_job_name,
         }
     return docs
-
-
-@hookimpl
-def custom_forward_model_outputs(forward_model_steps: List[str]) -> Set[str]:
-    outputs = set()
-    for step in forward_model_steps:
-        step_name, *args = step.split()
-        if step_name in get_forward_models():
-            try:
-                parser = import_module(
-                    f"{JOBS}.fm_{step_name}.parser"
-                ).build_argument_parser(skip_type=True)
-                options = parser.parse_args(args)
-                if "output" in options and options.output:
-                    outputs.add(options.output)
-            except (SystemExit, AttributeError):
-                pass
-    return outputs

--- a/src/everest_models/everest_hooks.py
+++ b/src/everest_models/everest_hooks.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Sequence, Type
 
 from pydantic import BaseModel
 
+from everest_models.forward_models import get_forward_models
 from everest_models.jobs.shared.io_utils import load_supported_file_encoding
 
 try:
@@ -108,3 +109,15 @@ def get_forward_model_documentations() -> Dict[str, Any]:
             "full_job_name": full_job_name,
         }
     return docs
+
+
+@hookimpl
+def check_forward_model_arguments(forward_model_steps: List[str]) -> None:
+    for step in forward_model_steps:
+        step_name, *args = step.split()
+        if step_name in get_forward_models():
+            parser = import_module(
+                f"{JOBS}.fm_{step_name}.parser"
+            ).build_argument_parser(skip_type=True)
+            parser.prog = f"fm_{step_name}"
+            parser.parse_args(args)

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -31,6 +31,41 @@ def test_get_forward_model_schemas_hook(plugin_manager):
     }
 
 
+@pytest.mark.parametrize(
+    ["fm_steps", "expected_error"],
+    [
+        (
+            [
+                "well_constraints   -c files/wc_config.yml -rc well_rate.json -o out1",
+            ],
+            "fm_well_constraints: error: the following arguments are required: -i/--input",
+        ),
+        (
+            [
+                "not_add_templates     -i wc_wells.json -c files/at_config.yml -o out2",
+                "schmerge           -i at_wells.json -o out3",
+                "rf -s TEST -o out4",
+            ],
+            "fm_schmerge: error: the following arguments are required: -s/--schedule",
+        ),
+        (
+            ["well_trajectory  -E eclipse/config/path"],
+            "fm_well_trajectory: error: the following arguments are required: -c/--config",
+        ),
+        ([], ""),
+    ],
+)
+def test_valid_fm_step_args(fm_steps, expected_error, plugin_manager, capsys):
+    if expected_error:
+        with pytest.raises(SystemExit):
+            plugin_manager.hook.check_forward_model_arguments(
+                forward_model_steps=fm_steps
+            )
+        assert expected_error in capsys.readouterr().err
+    else:
+        plugin_manager.hook.check_forward_model_arguments(forward_model_steps=fm_steps)
+
+
 def test_get_forward_model_schemas_hook_keys_are_options(plugin_manager):
     assert all(
         schema is not None

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -31,38 +31,6 @@ def test_get_forward_model_schemas_hook(plugin_manager):
     }
 
 
-@pytest.mark.parametrize(
-    ["fm_steps", "expected_results"],
-    [
-        (
-            [
-                "well_constraints  -i files/well_readydate.json -c files/wc_config.yml -rc well_rate.json -o out1",
-                "add_templates     -i wc_wells.json -c files/at_config.yml -o out2",
-                "schmerge          -s eclipse/include/schedule/schedule.tmpl -i at_wells.json -o out3",
-                "rf -s TEST -o out4",
-            ],
-            {"out1", "out2", "out3", "out4"},
-        ),
-        (
-            [
-                "well_constraints  -i files/well_readydate.json -c files/wc_config.yml -rc well_rate.json -o out1",
-                "not_add_templates     -i wc_wells.json -c files/at_config.yml -o out2",
-                "schmerge          -s eclipse/include/schedule/schedule.tmpl -i at_wells.json -o out3",
-                "rf -s TEST -o out4",
-            ],
-            {"out1", "out3", "out4"},
-        ),
-        (["well_trajectory -c config -E eclipse/config/path"], set()),
-        ([], set()),
-    ],
-)
-def test_returns_outputs_for_valid_steps(fm_steps, expected_results, plugin_manager):
-    result = plugin_manager.hook.custom_forward_model_outputs(
-        forward_model_steps=fm_steps
-    )
-    assert result[0] == expected_results
-
-
 def test_get_forward_model_schemas_hook_keys_are_options(plugin_manager):
     assert all(
         schema is not None

--- a/tests/jobs/well_swapping/test_well_swapping_cli.py
+++ b/tests/jobs/well_swapping/test_well_swapping_cli.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 from sub_testdata import WELL_SWAPPING as TEST_DATA
 
-from everest_models.everest_hooks import custom_forward_model_outputs
 from everest_models.jobs.fm_well_swapping.cli import main_entry_point
 from everest_models.jobs.shared.io_utils import load_json
 
@@ -60,12 +59,3 @@ def test_well_swapping_main_entrypoint_parse_fault(
         "error: argument -p/--priorities: All entries must contain the same amount of elements/indexes"
         in err
     )
-
-
-def test_custom_forward_model_outputs_hook(capsys):
-    custom_forward_model_outputs(
-        ["well_swapping  -c c.yml -p p.json -cr cr.json -cs cs.json -o o.json"]
-    )
-    out, err = capsys.readouterr()
-    assert out == ""
-    assert err == ""


### PR DESCRIPTION
Replaces the hook used in ert to check if the forward model does not output a file for the given objective function name with validation of the forward model arguments. 