### PR TITLE
Update outdated fm configs and change DataType well_swapping

### DIFF
--- a/docs/reference/well_constraints/config.yml
+++ b/docs/reference/well_constraints/config.yml
@@ -19,44 +19,40 @@
       # Default: null
       value: null
 
-    # Required: True
+    # Required: False
+    # Default: min=None max=None value=None
     rate:
 
-      # Datatype: number
-      # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+      # Datatype: number,
       # Required: False
       # Default: null
-      min: null
+      min: <REPLACE>
 
-      # Datatype: number
-      # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+      # Datatype: number,
       # Required: False
       # Default: null
-      max: null
+      max: <REPLACE>
 
-      # Datatype: number
-      # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+      # Datatype: number,
       # Required: False
       # Default: null
-      value: null
+      value: <REPLACE>
 
-    # Required: True
+    # Required: False
+    # Default: min=None max=None value=None
     duration:
 
-      # Datatype: number
-      # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+      # Datatype: number,
       # Required: False
       # Default: null
-      min: null
+      min: <REPLACE>
 
-      # Datatype: number
-      # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+      # Datatype: number,
       # Required: False
       # Default: null
-      max: null
+      max: <REPLACE>
 
-      # Datatype: number
-      # Examples: .1, 1., 1, 1.0, 1.34E-5, 1.34e-5
+      # Datatype: number,
       # Required: False
       # Default: null
-      value: null
+      value: <REPLACE>

--- a/docs/reference/well_swapping/config.yml
+++ b/docs/reference/well_swapping/config.yml
@@ -28,7 +28,7 @@ constraints:
 
     # Fallback values for each iteration if constraint JSON file is missing
     # Note: If a single number is given, all swapping intervals will be assigned that time duration
-    # Datatype: [integer] or integer
+    # Datatype: [number] or number
     # Examples: [150.0, 200, 500000.0], 200.0
     # Required: False
     # Default: null

--- a/docs/reference/well_trajectory/config.yml
+++ b/docs/reference/well_trajectory/config.yml
@@ -2,64 +2,6 @@
 # <REPLACE> is a REQUIRED field that needs replacing
 
 
-# Scaling lengths for the guide points.
-# Required: True
-scales:
-
-  # Scaling length for coordinate x for the guide points.
-  # Datatype: number
-  # Examples: 4000.0
-  # Required: True
-  x: <REPLACE>
-
-  # Scaling length for coordinate y for the guide points.
-  # Datatype: number
-  # Examples: 4000.0
-  # Required: True
-  y: <REPLACE>
-
-  # Scaling length for coordinate z (positive depth) for the guide points.
-  # Datatype: number
-  # Examples: 300.0
-  # Required: True
-  z: <REPLACE>
-
-  # Scaling length for z (positive depth) for the kick-off point.
-  # Datatype: number
-  # Examples: 50.0
-  # Required: False
-  # Default: null
-  k: null
-
-# Reference points for the guide points.
-# Required: True
-references:
-
-  # Coordinate x for reference point used in scaling of guide points.
-  # Datatype: number
-  # Examples: 5000.0
-  # Required: True
-  x: <REPLACE>
-
-  # Coordinate y for reference point used in scaling of guide points.
-  # Datatype: number
-  # Examples: 5000.0
-  # Required: True
-  y: <REPLACE>
-
-  # Coordinate z for reference point used in scaling of guide points.
-  # Datatype: number
-  # Examples: 8375.0
-  # Required: True
-  z: <REPLACE>
-
-  # Coordinate z for reference point used in scaling of kick-off point.
-  # Datatype: number
-  # Examples: 50.0
-  # Required: False
-  # Default: null
-  k: null
-
 # Options related to interpolation of guide points.
 # Required: True
 interpolation:

--- a/src/everest_models/jobs/fm_well_swapping/models/constraints.py
+++ b/src/everest_models/jobs/fm_well_swapping/models/constraints.py
@@ -40,7 +40,7 @@ class _Scaling(ModelConfig):
 
 class _Constraint(ModelConfig):
     fallback_values: Annotated[
-        Union[Tuple[int, ...], int],
+        Union[Tuple[float, ...], float],
         AfterValidator(min_length(1)),
         Field(
             default=None,
@@ -68,9 +68,9 @@ class Constraints(ModelConfig):
         ),
     ]
 
-    def rescale(self, constraints: Union[Sequence[float], int]) -> Tuple[int, ...]:
+    def rescale(self, constraints: Union[Sequence[float], int]) -> Tuple[float, ...]:
         if isinstance(constraints, int):
-            if isinstance(self.state_duration.fallback_values, int):
+            if isinstance(self.state_duration.fallback_values, float):
                 if not constraints:
                     raise ValueError(
                         "Unable to build state duration fallback constraints."


### PR DESCRIPTION
Resolves: [#69](https://github.com/equinor/everest-models/issues/69)

Also updated outdated configs for recently updated forward models (`well_constraints` and `well_trajectory`), apparently we didn't `run doc_schemas.py` after we updated the scaling in aforementioned forward models.

PS: Still looking into the 'number' instead of just number (but we can fix that in another PR too).  