### PR TITLE
Parse well swapping constraint bounds as float directly

### DIFF
--- a/docs/reference/well_swapping/config.yml
+++ b/docs/reference/well_swapping/config.yml
@@ -149,11 +149,12 @@ state:
 
   # List of directional (source → target) state update actions.
   # Note: action context is set with the 'forbiden_actions' field
-  # Datatype: [['string', 'string']]
+  # Datatype: [[string, string]]
   # Required: False
   # Default: null
   actions:
-    - <REPLACE>
+    -   - <REPLACE>
+        - <REPLACE>
 
   # Are cases allowed to stay at the same state?
   # False: Enforce cases to change state each iteration, (can cause state lock)

--- a/docs/reference/well_swapping/config.yml
+++ b/docs/reference/well_swapping/config.yml
@@ -40,16 +40,20 @@ constraints:
     scaling:
 
       # [min, max] values for scaling source
-      # Datatype: ['number', 'number']
+      # Datatype: [number, number]
       # Examples: [0, 1], [0.0, 1.0], [0.5, 2.0]
       # Required: True
-      source: <REPLACE>
+      source:
+        - <REPLACE>
+        - <REPLACE>
 
       # [min, max] values for scaling target (in days)
-      # Datatype: ['number', 'number']
+      # Datatype: [number, number]
       # Examples: [0, 500], [100.0, 400.0], [150.0, 1000.0]
       # Required: True
-      target: <REPLACE>
+      target:
+        - <REPLACE>
+        - <REPLACE>
 
 # Fallback values for item priorities in case priority JSON file is missing (e.g. when priority controls are not defined in Everest configuration file)
 # Required: False

--- a/src/everest_models/jobs/fm_well_swapping/models/constraints.py
+++ b/src/everest_models/jobs/fm_well_swapping/models/constraints.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Sequence, Tuple, Union
+from typing import Sequence, Tuple, Union
 
 from pydantic import AfterValidator, Field, field_validator
 from typing_extensions import Annotated
@@ -8,21 +8,16 @@ from everest_models.jobs.shared.models import ModelConfig
 from everest_models.jobs.shared.validators import min_length
 
 
-class _Bound(NamedTuple):
-    min: float
-    max: float
-
-
 class _Scaling(ModelConfig):
     source: Annotated[
-        _Bound,
+        Tuple[float, float],
         Field(
             description="[min, max] values for scaling source",
             examples=[[0, 1], [0.0, 1.0], [0.5, 2.0]],
         ),
     ]
     target: Annotated[
-        _Bound,
+        Tuple[float, float],
         Field(
             description="[min, max] values for scaling target (in days)",
             examples=[[0, 500], [100.0, 400.0], [1.5e2, 1.0e3]],
@@ -30,7 +25,7 @@ class _Scaling(ModelConfig):
     ]
 
     @field_validator("*", mode="after")
-    def valid_bound(cls, bound: _Bound) -> _Bound:
+    def valid_bound(cls, bound: Tuple[float, float]) -> Tuple[float, float]:
         if bound.min > bound.max:
             raise ValueError(
                 f"[min, max], where min cannot be greater than max: {list(bound)}"

--- a/src/everest_models/jobs/fm_well_swapping/models/state.py
+++ b/src/everest_models/jobs/fm_well_swapping/models/state.py
@@ -179,7 +179,7 @@ class StateConfig(ModelConfig):
         ),
     ]
     actions: Annotated[
-        Tuple[Action, ...],
+        Tuple[Tuple[State, State], ...],
         AfterValidator(unique_values),
         Field(
             default=None,


### PR DESCRIPTION
Resolves: [#69](https://github.com/equinor/everest-models/issues/69)

This resolves the second part of the story (inconsistency between 'number' and number && 'string' and string). If anyone understands why this is necessary and has a better solution, please let me know, since I don't think this is very pretty and I don't understand why the old solution didn't work :)...