### PR TITLE
Do not ignore .github in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,8 @@ venv.bak/
 # vscode
 .vscode
 
+# neovim/ripgrep (reversed rule)
+!.github
+
 # version
 src/everest_models/version.py


### PR DESCRIPTION
This allows ripgrep and IDEs (at least neovim) to also find files in .github