### PR TITLE
Mark resinsight integration tests as xfail

### DIFF
--- a/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
@@ -67,6 +67,7 @@ def test_well_trajectory_resinsight_main_entry_point_no_mlt(
             assert filecmp.cmp(expected, output, shallow=False)
 
 
+@pytest.mark.xfail
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_mlt(
     well_trajectory_arguments, copy_testdata_tmpdir
@@ -81,6 +82,7 @@ def test_well_trajectory_resinsight_main_entry_point_mlt(
             assert filecmp.cmp(expected, output, shallow=False)
 
 
+@pytest.mark.xfail
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_mixed(
     well_trajectory_arguments, copy_testdata_tmpdir


### PR DESCRIPTION
These tests are currently too specific and vulnerable to minute
and acceptable changes in resinsight versions.