### PR TITLE
Mark failing tests as XFAIL

### DIFF
--- a/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
@@ -51,6 +51,7 @@ def test_well_trajectory_resinsight_main_entry_point_lint(
     )
 
 
+@pytest.mark.xfail
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_no_mlt(
     well_trajectory_arguments, copy_testdata_tmpdir
@@ -103,6 +104,7 @@ def test_well_trajectory_resinsight_main_entry_point_mixed(
             assert filecmp.cmp(expected, output, shallow=False)
 
 
+@pytest.mark.xfail
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_no_mlt_static_perforation(
     copy_testdata_tmpdir,
@@ -119,6 +121,7 @@ def test_well_trajectory_resinsight_main_entry_point_no_mlt_static_perforation(
             assert filecmp.cmp(expected, output, shallow=False)
 
 
+@pytest.mark.xfail
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_no_mlt_dynamic_perforation(
     copy_testdata_tmpdir,


### PR DESCRIPTION
These tests are vulnerable to implementation details, as in whether '1*' is used insted of explicit values when the values are the same as default.