### PR TITLE
Add temporary `xfail` for multilateral well tests due to breaking API change in rips

### DIFF
--- a/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
@@ -101,6 +101,9 @@ def test_well_trajectory_resinsight_main_entry_point_no_mlt(
     _assert_deviation_files_nonempty(Path.cwd() / "wellpaths", expected_dev_files)
 
 
+@pytest.mark.xfail(
+    reason="recent breaking change in rips API for multilateral wells -> remove xfail once this is fixed"
+)
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_mlt(
     well_trajectory_arguments, copy_testdata_tmpdir
@@ -134,6 +137,9 @@ def test_well_trajectory_resinsight_main_entry_point_mlt(
     _assert_deviation_files_nonempty(Path.cwd() / "wellpaths", expected_dev_files)
 
 
+@pytest.mark.xfail(
+    reason="recent breaking change in rips API for multilateral wells -> remove xfail once this is fixed"
+)
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_mixed(
     well_trajectory_arguments, copy_testdata_tmpdir


### PR DESCRIPTION
Once the API has been fixed, this change needs to be reverted.