### PR TITLE
Adapt tests for forward model step refactor

### DIFF
--- a/tests/integration/test_eightcells_simulation.py
+++ b/tests/integration/test_eightcells_simulation.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from ert.ensemble_evaluator import EvaluatorServerConfig
+from ert.plugins import ErtPluginContext
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.bin.main import start_everest
 from everest.config import EverestConfig
@@ -72,7 +73,9 @@ def test_lint_everest_models_jobs():
 def test_init_no_project_res(copy_eightcells_test_data_to_tmp):
     config_file = os.path.join("everest", "model", "config.yml")
     config = EverestConfig.load_file(config_file)
-    EverestRunModel.create(config)
+
+    with ErtPluginContext() as runtime_plugins:
+        EverestRunModel.create(config, runtime_plugins=runtime_plugins)
 
 
 def test_everest_main_configdump_entry(copy_eightcells_test_data_to_tmp):

--- a/tests/jobs/well_swapping/test_well_swapping_integration.py
+++ b/tests/jobs/well_swapping/test_well_swapping_integration.py
@@ -3,6 +3,7 @@ from typing import Callable
 
 import pytest
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
+from ert.plugins import ErtPluginContext
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
 
@@ -16,9 +17,11 @@ def test_state_modifier_workflow_run(
 ) -> None:
     cwd = copy_testdata_tmpdir("open_shut_state_modifier")
 
-    run_model = EverestRunModel.create(
-        EverestConfig.load_file(f"everest/model/{config}.yml")
-    )
+    with ErtPluginContext() as runtime_plugins:
+        run_model = EverestRunModel.create(
+            EverestConfig.load_file(f"everest/model/{config}.yml"),
+            runtime_plugins=runtime_plugins,
+        )
     evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
     paths = list(Path.cwd().glob("**/evaluation_0/RESULT.SCH"))


### PR DESCRIPTION
The EverestRunModel.create must have the plugin context since some Everest forward models installed via plugins are assumed to always exist.