### PR TITLE
Remove `xfail` from well-trajectory tests

### DIFF
--- a/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
@@ -101,9 +101,6 @@ def test_well_trajectory_resinsight_main_entry_point_no_mlt(
     _assert_deviation_files_nonempty(Path.cwd() / "wellpaths", expected_dev_files)
 
 
-@pytest.mark.xfail(
-    reason="recent breaking change in rips API for multilateral wells -> remove xfail once this is fixed"
-)
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_mlt(
     well_trajectory_arguments, copy_testdata_tmpdir
@@ -137,9 +134,6 @@ def test_well_trajectory_resinsight_main_entry_point_mlt(
     _assert_deviation_files_nonempty(Path.cwd() / "wellpaths", expected_dev_files)
 
 
-@pytest.mark.xfail(
-    reason="recent breaking change in rips API for multilateral wells -> remove xfail once this is fixed"
-)
 @pytest.mark.resinsight
 def test_well_trajectory_resinsight_main_entry_point_mixed(
     well_trajectory_arguments, copy_testdata_tmpdir


### PR DESCRIPTION
Resolves: #180 

After the recent fix by the ResInsight team (https://github.com/OPM/ResInsight/commit/519a28d58373df45af2fe82cade635b5a1a03831) the workflow should be running again, I wanted to run it manually on Remote Desktop with the latest bleeding, but then maybe this should be enough evidence that it works: https://github.com/equinor/komodo-releases/actions/runs/18267174131/job/52004038823#step:5:639 (i.e., 2 xpassed instead of xfail :))

It is noted though by Magne that `WellPath` doesn't contain this method, only `ModeledWellPath` does (https://api.resinsight.org/en/next-major-release/api/rips.ModeledWellPath.html#rips.ModeledWellPath.append_lateral), so maybe we should add proper type hints to the well-trajectory forward model here: https://github.com/equinor/everest-models/blob/main/src/everest_models/jobs/fm_well_trajectory/resinsight.py#L67 (return not `Any` but explicitly `ModeledWellPath`? Can do it on this PR as an additional commit?