### PR TITLE
Fix eightcells everest config

### DIFF
--- a/tests/testdata/eightcells/everest/model/config.yml
+++ b/tests/testdata/eightcells/everest/model/config.yml
@@ -9,6 +9,7 @@ controls:
   -
     name: well_rate
     type: generic_control
+    perturbation_magnitude: 50
     variables:
       -
         name: OP1


### PR DESCRIPTION
The everest configuration requires the perturbation_magnitude field.

Required due to: https://github.com/equinor/ert/pull/12000