### PR TITLE
Add proper type hint for rips wellpaths

### DIFF
--- a/src/everest_models/jobs/fm_well_trajectory/resinsight.py
+++ b/src/everest_models/jobs/fm_well_trajectory/resinsight.py
@@ -64,7 +64,7 @@ def create_well(
     well_config: WellConfig,
     guide_points: Trajectory,
     project: rips.Project,
-) -> Any:
+) -> rips.ModeledWellPath:
     _create_perforation_view(
         connection.perforations,
         connection.formations_file,
@@ -118,7 +118,7 @@ def create_well(
 
 def create_branches(
     well_config: WellConfig,
-    well_path: Any,
+    well_path: rips.ModeledWellPath,
     mlt_guide_points: Dict[str, Tuple[float, Trajectory]],
     project: rips.Project,
 ) -> Any:


### PR DESCRIPTION
After a recent fix in rips it became clear that only the derived class `ModeledWellPath` contains the method we are using in our workflow for adding laterals. This PR adds type hinting to avoid confusion. As far as I can see it is OK to leave the other reference to base class `WellPath` in `create_well_logs()` and `_create_tracks()` (i.e., polymorphism).