### PR TITLE
Remove extension from simulator model path for fm_well_trajectory

### DIFF
--- a/src/everest_models/jobs/shared/validators.py
+++ b/src/everest_models/jobs/shared/validators.py
@@ -78,7 +78,7 @@ def validate_eclipse_path(path: pathlib.Path) -> pathlib.Path:
         raise ValueError(f"Directory {path.parent} not found")
     if not any(path.parent.glob(f"{path.stem}.*")):
         raise ValueError(f"Model '{path.stem}' not present in directory: {path.parent}")
-    return path
+    return path.with_suffix("")
 
 
 def validate_eclipse_path_argparse(path: str) -> pathlib.Path:

--- a/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
@@ -274,3 +274,8 @@ def test_validate_files_required_for_dynamic_perforation(copy_testdata_tmpdir, c
     assert excinfo.value.code == 2
     captured = capsys.readouterr()
     assert "Missing SPE1CASE1.UNRST file" in captured.err
+
+
+def test_specifying_eclipse_model_with_extension(copy_testdata_tmpdir):
+    copy_testdata_tmpdir(Path(TEST_DATA) / "resinsight")
+    main_entry_point(["-c", "config.yml", "-E", "SPE1CASE1.EGRID"])


### PR DESCRIPTION
Resolves: #154 

Solution: just remove any suffix from the model path when validating (this same code is hit in both cases of CLI or specifying in the trajectory configuration file).

As mentioned in the docs of `eclipse_model` in the config: `examples="/path/to/MODEL.EGRID"` and the text for the argparser:
`"Path to simulation model: '/path/to/model'; extension not required. "` (note: extension not required, meaning you can provide with or without the extension).