### PR TITLE
Remove unused yaml files well_constraints fm

### DIFF
--- a/docs/reference/well_constraints/duration_constraints.yml
+++ b/docs/reference/well_constraints/duration_constraints.yml
@@ -1,5 +1,0 @@
-# -dc/--duration-constraints specification:
-# <REPLACE> is a REQUIRED field that needs replacing
-
-<STRING>:
-  <INTEGER>: <REPLACE>

--- a/docs/reference/well_constraints/phase_constraints.yml
+++ b/docs/reference/well_constraints/phase_constraints.yml
@@ -1,5 +1,0 @@
-# -pc/--phase-constraints specification:
-# <REPLACE> is a REQUIRED field that needs replacing
-
-<STRING>:
-  <INTEGER>: <REPLACE>

--- a/docs/reference/well_constraints/rate_constraints.yml
+++ b/docs/reference/well_constraints/rate_constraints.yml
@@ -1,5 +1,0 @@
-# -rc/--rate-constraints specification:
-# <REPLACE> is a REQUIRED field that needs replacing
-
-<STRING>:
-  <INTEGER>: <REPLACE>

--- a/docs/reference/well_constraints/reference.md
+++ b/docs/reference/well_constraints/reference.md
@@ -8,20 +8,6 @@
 {!> reference/well_constraints/config.yml!}
 ```
 
-### Constraints
-
-```yaml
-{!> reference/well_constraints/duration_constraints.yml!}
-```
-
-```yaml
-{!> reference/well_constraints/phase_constraints.yml!}
-```
-
-```yaml
-{!> reference/well_constraints/rate_constraints.yml!}
-```
-
 ## Tasks
 
 ::: everest_models.jobs.fm_well_constraints.tasks

--- a/src/everest_models/jobs/fm_well_constraints/parser.py
+++ b/src/everest_models/jobs/fm_well_constraints/parser.py
@@ -24,9 +24,6 @@ DURATION_CONSTRAINTS_ARG_KEY = "-dc/--duration-constraints"
 
 SCHEMAS = {
     CONFIG_ARG_KEY: WellConstraintConfig,
-    RATE_CONSTRAINTS_ARG_KEY: Control,
-    PHASE_CONSTRAINTS_ARG_KEY: PhaseControl,
-    DURATION_CONSTRAINTS_ARG_KEY: Control,
 }
 
 


### PR DESCRIPTION
Currently the `fm_well_constraints --schema` generates a schema for the well constraints forward model which includes three  `yaml` specifications (inside the main schema) for EVEREST generated JSON files (based on the controls section of the main EVEREST config). These are misleading/confusing and not relevant for the user in the first place.