### PR TITLE
Add date to dynamic perforations only

### DIFF
--- a/docs/reference/well_trajectory/config.yml
+++ b/docs/reference/well_trajectory/config.yml
@@ -53,12 +53,6 @@ connections:
   # Default: resinsight
   type: resinsight
 
-  # Simulation date used for grid perforation filtering based on time dynamic grid flow simulation data.
-  # Datatype: date
-  # Examples: 2024-01-31, 2024-01-31T11:06
-  # Required: True
-  date: <REPLACE>
-
   # File defining list of grid based geological formations used for perforation filtering based on formations.
   # Datatype: Path
   # Examples: /path/to/formations.lyr
@@ -96,6 +90,12 @@ connections:
           # Examples: 0.3
           # Required: True
           max: <REPLACE>
+
+          # Simulation date used for grid perforation filtering based on time dynamic grid flow simulation data.
+          # Datatype: date
+          # Required: False
+          # Default: null
+          date: <REPLACE>
 
       # Required: False
       static:

--- a/src/everest_models/jobs/fm_well_trajectory/cli.py
+++ b/src/everest_models/jobs/fm_well_trajectory/cli.py
@@ -25,21 +25,21 @@ Argument examples
 
     connections:
         type: resinsight
-        date: 2015-01-02
         formations_file: ./formations.lyr
         perforations:
             - well: INJ
               formations: [3, 4]
             - well: PROD
               formations: [1, 2, 3, 4]
-        static:
-            - key: PORO
-              min: 0
-              max: 1
-        dynamic:
-            - key: SWAT
-              min: 0
-              max: 0.5
+              static:
+                - key: PORO
+                  min: 0
+                  max: 1
+              dynamic:
+                - key: SWAT
+                  min: 0
+                  max: 0.5
+                  date: 2015-01-02
 
     wells:
         - name: INJ

--- a/src/everest_models/jobs/fm_well_trajectory/well_trajectory_resinsight.py
+++ b/src/everest_models/jobs/fm_well_trajectory/well_trajectory_resinsight.py
@@ -133,7 +133,6 @@ def well_trajectory_resinsight(
             resinsight.project,
             eclipse_model,
             project_path,
-            config.connections.date,
         )
         wells = itertools.filterfalse(
             lambda x: x is None,

--- a/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
@@ -6,6 +6,7 @@ import sys
 from importlib.util import find_spec
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from sub_testdata import WELL_TRAJECTORY as TEST_DATA
 
@@ -13,6 +14,7 @@ if find_spec("rips") is None:
     pytest.skip("Skipping tests: 'rips' is not installed", allow_module_level=True)
 
 from everest_models.jobs.fm_well_trajectory.cli import main_entry_point
+from everest_models.jobs.fm_well_trajectory.resinsight import _read_and_merge_las
 from everest_models.jobs.fm_well_trajectory.well_trajectory_resinsight import ResInsight
 
 _builtin_import = builtins.__import__
@@ -279,3 +281,38 @@ def test_validate_files_required_for_dynamic_perforation(copy_testdata_tmpdir, c
 def test_specifying_eclipse_model_with_extension(copy_testdata_tmpdir):
     copy_testdata_tmpdir(Path(TEST_DATA) / "resinsight")
     main_entry_point(["-c", "config.yml", "-E", "SPE1CASE1.EGRID"])
+
+
+def test_reading_several_las_files(copy_testdata_tmpdir):
+    test_dir = copy_testdata_tmpdir(Path(TEST_DATA) / "resinsight" / "las_files")
+    well_name = "PROD"
+
+    expected_well_log = pd.DataFrame(
+        {
+            "DEPTH": [8448.617, 8468.633, 8468.633, 8498.637, 8498.637, 8548.637],
+            "TVDMSL": [8325.0, 8345.0, 8345.0, 8375.0, 8375.0, 8425.0],
+            "TVDRKB": [8325.0, 8345.0, 8345.0, 8375.0, 8375.0, 8425.0],
+            "SOIL": [0.879899, 0.879899, 0.879900, 0.879900, 0.879901, 0.879901],
+            "PRESSURE": [4779.543, 4779.543, 4780.948, 4780.948, 4783.049, 4783.049],
+            "PORO": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3],
+            "ACTIVE_FORMATION_NAMES": [0.0, 0.0, 1.0, 1.0, 2.0, 2.0],
+        }
+    )
+
+    # Testing private method here to avoid mock-city of ResInsight and avoid
+    # putting back snaphots of files produced by ResInsight...
+    combined_well_log = _read_and_merge_las(path=test_dir, well_name=well_name)
+    pd.testing.assert_frame_equal(
+        combined_well_log, expected_well_log, check_dtype=False, atol=1e-6
+    )
+
+
+def test_reading_las_file_different_length(copy_testdata_tmpdir):
+    test_dir = copy_testdata_tmpdir(Path(TEST_DATA) / "resinsight" / "las_files")
+    well_name = "INJ"
+
+    with pytest.raises(
+        ValueError,
+        match="LAS file INJ_SPE1CASE1-01_Jan_2015 has 4 rows, expected 6",
+    ):
+        _read_and_merge_las(path=test_dir, well_name=well_name)

--- a/tests/testdata/well_trajectory/resinsight/config.yml
+++ b/tests/testdata/well_trajectory/resinsight/config.yml
@@ -3,7 +3,6 @@ interpolation:
   measured_depth_step: 5.0
 connections:
   type: resinsight
-  date: 2015-01-02
   formations_file: ./formations.lyr
   perforations:
   - well: INJ

--- a/tests/testdata/well_trajectory/resinsight/config_dynamic_perforation.yml
+++ b/tests/testdata/well_trajectory/resinsight/config_dynamic_perforation.yml
@@ -3,14 +3,23 @@ interpolation:
   measured_depth_step: 5.0
 connections:
   type: resinsight
-  date: 2015-01-02
   formations_file: ./formations.lyr
   perforations:
     - well: INJ
       formations: [0, 1, 2]
     - well: PROD
+      formations: [0, 2]
       dynamic:
         - key: SOIL
+          min: 0
+          max: 1
+          date: 2015-01-02
+        - key: PRESSURE
+          min: 0
+          max: 100000
+          date: 2015-01-02
+      static:
+        - key: PORO
           min: 0
           max: 1
 wells:

--- a/tests/testdata/well_trajectory/resinsight/config_missing_date.yml
+++ b/tests/testdata/well_trajectory/resinsight/config_missing_date.yml
@@ -3,7 +3,6 @@ interpolation:
   measured_depth_step: 5.0
 connections:
   type: resinsight
-  date: 2015-01-03
   formations_file: ./formations.lyr
   perforations:
     - well: INJ
@@ -13,6 +12,7 @@ connections:
         - key: SOIL
           min: 0
           max: 1
+          date: 2015-01-03
 wells:
   - name: INJ
     group: G1

--- a/tests/testdata/well_trajectory/resinsight/config_static_perforation.yml
+++ b/tests/testdata/well_trajectory/resinsight/config_static_perforation.yml
@@ -3,7 +3,6 @@ interpolation:
   measured_depth_step: 5.0
 connections:
   type: resinsight
-  date: 2015-01-02
   formations_file: ./formations.lyr
   perforations:
     - well: INJ

--- a/tests/testdata/well_trajectory/resinsight/las_files/INJ_SPE1CASE1-01_Jan_2015.las
+++ b/tests/testdata/well_trajectory/resinsight/las_files/INJ_SPE1CASE1-01_Jan_2015.las
@@ -1,0 +1,27 @@
+#
+~Version information
+VERS . 2.0 :
+WRAP . NO :
+#
+~Well information
+STRT .M 8448.61724 :
+STOP .M 8548.63718 :
+STEP .M 0.00000 :
+NULL . -999.25000 :
+WELL . PROD :
+DATE . 01_Jan_2015 :
+#
+~Parameter information
+#
+~Curve information
+DEPTH .M  : Depth in meters
+TVDMSL .M  : True vertical depth in meters
+TVDRKB .M  : True vertical depth (Rotary Kelly Bushing)
+PORO .NO_UNIT  :
+Active_Formation_Names .NO_UNIT  :
+#
+~Ascii
+8448.617 8325.000 8325.000 0.300000 0.000
+8468.633 8345.000 8345.000 0.300000 0.000
+8498.637 8375.000 8375.000 0.300000 2.000000
+8548.637 8425.000 8425.000 0.300000 2.000000

--- a/tests/testdata/well_trajectory/resinsight/las_files/INJ_SPE1CASE1-02_Jan_2015.las
+++ b/tests/testdata/well_trajectory/resinsight/las_files/INJ_SPE1CASE1-02_Jan_2015.las
@@ -1,0 +1,29 @@
+#
+~Version information
+VERS . 2.0 :
+WRAP . NO :
+#
+~Well information
+STRT .M 8448.61724 :
+STOP .M 8548.63718 :
+STEP .M 0.00000 :
+NULL . -999.25000 :
+WELL . PROD :
+DATE . 02_Jan_2015 :
+#
+~Parameter information
+#
+~Curve information
+DEPTH .M  : Depth in meters
+TVDMSL .M  : True vertical depth in meters
+TVDRKB .M  : True vertical depth (Rotary Kelly Bushing)
+SOIL .NO_UNIT  :
+PRESSURE .NO_UNIT  :
+#
+~Ascii
+8448.617 8325.000 8325.000 0.879899 4779.543
+8468.633 8345.000 8345.000 0.879899 4779.543
+8468.633 8345.000 8345.000 0.879900 4780.948
+8498.637 8375.000 8375.000 0.879900 4780.948
+8498.637 8375.000 8375.000 0.879901 4783.049
+8548.637 8425.000 8425.000 0.879901 4783.049

--- a/tests/testdata/well_trajectory/resinsight/las_files/PROD_SPE1CASE1-01_Jan_2015.las
+++ b/tests/testdata/well_trajectory/resinsight/las_files/PROD_SPE1CASE1-01_Jan_2015.las
@@ -1,0 +1,29 @@
+#
+~Version information
+VERS . 2.0 :
+WRAP . NO :
+#
+~Well information
+STRT .M 8448.61724 :
+STOP .M 8548.63718 :
+STEP .M 0.00000 :
+NULL . -999.25000 :
+WELL . PROD :
+DATE . 01_Jan_2015 :
+#
+~Parameter information
+#
+~Curve information
+DEPTH .M  : Depth in meters
+TVDMSL .M  : True vertical depth in meters
+TVDRKB .M  : True vertical depth (Rotary Kelly Bushing)
+PORO .NO_UNIT  :
+Active_Formation_Names .NO_UNIT  :
+#
+~Ascii
+8448.617 8325.000 8325.000 0.300000 0.000
+8468.633 8345.000 8345.000 0.300000 0.000
+8468.633 8345.000 8345.000 0.300000 1.000000
+8498.637 8375.000 8375.000 0.300000 1.000000
+8498.637 8375.000 8375.000 0.300000 2.000000
+8548.637 8425.000 8425.000 0.300000 2.000000

--- a/tests/testdata/well_trajectory/resinsight/las_files/PROD_SPE1CASE1-02_Jan_2015.las
+++ b/tests/testdata/well_trajectory/resinsight/las_files/PROD_SPE1CASE1-02_Jan_2015.las
@@ -1,0 +1,29 @@
+#
+~Version information
+VERS . 2.0 :
+WRAP . NO :
+#
+~Well information
+STRT .M 8448.61724 :
+STOP .M 8548.63718 :
+STEP .M 0.00000 :
+NULL . -999.25000 :
+WELL . PROD :
+DATE . 02_Jan_2015 :
+#
+~Parameter information
+#
+~Curve information
+DEPTH .M  : Depth in meters
+TVDMSL .M  : True vertical depth in meters
+TVDRKB .M  : True vertical depth (Rotary Kelly Bushing)
+SOIL .NO_UNIT  :
+PRESSURE .NO_UNIT  :
+#
+~Ascii
+8448.617 8325.000 8325.000 0.879899 4779.543
+8468.633 8345.000 8345.000 0.879899 4779.543
+8468.633 8345.000 8345.000 0.879900 4780.948
+8498.637 8375.000 8375.000 0.879900 4780.948
+8498.637 8375.000 8375.000 0.879901 4783.049
+8548.637 8425.000 8425.000 0.879901 4783.049


### PR DESCRIPTION
Resolves: #192 
Resolves: #200 

**TLDR**: Adding two (or more) LAS files together without assuming they are the same length (i.e., number of rows) and contain the same `DEPTH` values is way too  complicated for something that (most likely) never happens (decided after some discussion with an expert user at TNO). Therefore, we assume in this solution that LAS files for the same well have the same length and same `DEPTH` values.

**NOTE:** This change breaks the `well-trajectory` config:
(old)
```
connections:
  ...
  date: 2015-01-01
  perforations:
    ...
    - well: PROD
      static:
        - key: PORO
        ...
```
(new)
```
connections:
  ...
  perforations:
    ...
    - well: PROD
      dynamic:
        - key: SOIL
          min: 0
          max: 1
          date: 2015-01-02
      static:
        - key: PORO
        ...
```
Added a deprecation message (instead of the more cryptic pydantic error). Will bump up the version of `everest-models` and modify the well-trajectory tutorial in `everest-tutorials` after this is in.

----------

_Background for the proposed solution_:
LAS files are written by ResInsight for each date a property is recorded (properties are added to a well_log as a track, which contains a date, all properties recorded at the same date are written to the same LAS file by ResInsight). This means that at least static (t=0) and dynamic (t>0) properties are written to different files (for the same well), meaning we should at least be reading two LAS files in that case (more LAS files if a different date is used for different dynamic properties). 

LAS files have the following format (example):
```
      DEPTH  TVDMSL  TVDRKB  ACTIVE_FORMATION_NAMES
0  8448.617  8325.0  8325.0                     0.0
1  8468.633  8345.0  8345.0                     0.0
2  8468.633  8345.0  8345.0                     1.0
3  8498.637  8375.0  8375.0                     1.0
4  8498.637  8375.0  8375.0                     2.0
5  8548.637  8425.0  8425.0                     2.0
```
row 0 - 1 is segment 0, row 2 - 3 is segment 1 --> segment i is row `2*i - 2*i + 1`. This is necessarily to later filter out perforations. For example, if we filter out formation 1:
```
      DEPTH  TVDMSL  TVDRKB  ACTIVE_FORMATION_NAMES
0  8448.617  8325.0  8325.0                     0.0
1  8468.633  8345.0  8345.0                     0.0
2  8498.637  8375.0  8375.0                     2.0
3  8548.637  8425.0  8425.0                     2.0
```
deletes segment 1, and the perforation length for the other segments doesn't change. If we would define segments as: segment i is row i - row i+1, and then filter out duplicate entries from the LAS for DEPTH, TVDMSL, TVDRKB we get:
```
      DEPTH  TVDMSL  TVDRKB  ACTIVE_FORMATION_NAMES
0  8448.617  8325.0  8325.0                     0.0
1  8468.633  8345.0  8345.0                     0.0
2  8498.637  8375.0  8375.0                     1.0
3  8548.637  8425.0  8425.0                     2.0
```
This will create a problem when we want to filter out formation 1:
```
      DEPTH  TVDMSL  TVDRKB  ACTIVE_FORMATION_NAMES
0  8448.617  8325.0  8325.0                     0.0
1  8468.633  8345.0  8345.0                     0.0
2  8548.637  8425.0  8425.0                     2.0
```
segment 2 now has length 8548.637 - 8468.633 (instead of the correct 8548.637 - 8498.637). 

Therefore, when we join to LAS files, we must preserve the original structure of segment i is row `2*i - 2*i + 1`. When doing a simple inner merge, it will create a cartesian product which contains nonsensical segments with zero length (simply because both dataframes contain duplicated rows for `DEPTH  TVDMSL  TVDRKB` due to the start- and end- of a segment that (can) have different values for the properties as they usually mark a jump in formation/cell and hence (can) have different properties). For example:
LAS file: PROD-SPE1CASE1-01_Jan_2015.las
```
      DEPTH  TVDMSL  TVDRKB  PORO  ACTIVE_FORMATION_NAMES
0  8448.617  8325.0  8325.0   0.3                     0.0
1  8468.633  8345.0  8345.0   0.3                     0.0
2  8468.633  8345.0  8345.0   0.3                     1.0
3  8498.637  8375.0  8375.0   0.3                     1.0
4  8498.637  8375.0  8375.0   0.3                     2.0
5  8548.637  8425.0  8425.0   0.3                     2.0
```  
and LAS file: PROD-SPE1CASE1-02_Jan_2015.las
```
      DEPTH  TVDMSL  TVDRKB      SOIL  PRESSURE
0  8448.617  8325.0  8325.0  0.879899  4779.543
1  8468.633  8345.0  8345.0  0.879899  4779.543
2  8468.633  8345.0  8345.0  0.879900  4780.948
3  8498.637  8375.0  8375.0  0.879900  4780.948
4  8498.637  8375.0  8375.0  0.879901  4783.049
5  8548.637  8425.0  8425.0  0.879901  4783.049
```
will result in the joined DataFrame:
```
      DEPTH  TVDMSL  TVDRKB  PORO  ACTIVE_FORMATION_NAMES      SOIL  PRESSURE
0  8448.617  8325.0  8325.0   0.3                     0.0  0.879899  4779.543
1  8468.633  8345.0  8345.0   0.3                     0.0  0.879899  4779.543
2  8468.633  8345.0  8345.0   0.3                     0.0  0.879900  4780.948
3  8468.633  8345.0  8345.0   0.3                     1.0  0.879899  4779.543
4  8468.633  8345.0  8345.0   0.3                     1.0  0.879900  4780.948
5  8498.637  8375.0  8375.0   0.3                     1.0  0.879900  4780.948
6  8498.637  8375.0  8375.0   0.3                     1.0  0.879901  4783.049
7  8498.637  8375.0  8375.0   0.3                     2.0  0.879900  4780.948
8  8498.637  8375.0  8375.0   0.3                     2.0  0.879901  4783.049
9  8548.637  8425.0  8425.0   0.3                     2.0  0.879901  4783.049
```
with rows 2-3 and 6-7 being nonsensical (i.e., wrong).

To circumvent this, I initially proposed a solution that is slightly complicated if we want to guard against the fact that the number of active cells that a well penetrates can change over the course of simulation. This was done using an iterative inner join. However, this still did work when files have different length, the resulting dataframe doesn't properly join to adhere to the format of segment i is row `2*i - 2*i + 1`...

It get's a lot easier if we make the assumption that the size of the LAS file (i.e., cells the well perforates) doesn't change over time --> simply concatenate all dfs to the first one (minus the duplicated colums `DEPTH  TVDMSL  TVDRKB`). ~~I tried a third option, merge_asof with forward direction, but this doesn't result in the correct dataframe (for each merged dataframe it takes the wrong value for properties that changes between segments).~~