### PR TITLE
Only install test dependencies in testkomodo

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -4,7 +4,11 @@ copy_test_files () {
 }
 
 install_test_dependencies () {
-    pip install .[test]
+    python -c "import tomllib; \
+deps = tomllib.load(open('pyproject.toml', 'rb'))\
+['project']['optional-dependencies']['test'];\
+print('\n'.join(deps))" > dev_requirements.txt
+    pip install -r dev_requirements.txt
 }
 
 start_tests () {


### PR DESCRIPTION
Running `pip install .[test]` also runs pip install on normal dependencies. When we have specified a https-address for fmu-steaclient in pyproject.toml, it will prefer that over any fmu-steaclient already existing in its venv, which is wrong when doing komodo integration tests.

By extracting the test dependencies only, and on-the-fly, we can install only these and ensure that fmu-steaclient is not attempted upgraded.