### PR TITLE
Make file reading order deterministic

### DIFF
--- a/src/everest_models/jobs/fm_well_trajectory/resinsight.py
+++ b/src/everest_models/jobs/fm_well_trajectory/resinsight.py
@@ -386,7 +386,7 @@ def _read_and_merge_las(path: Path, well_name: str) -> pd.DataFrame:
     # LAS files are generated per track (well?) for each date
     # a property is extracted from ResInsight, in the form:
     # <well_name>-<case_name>-(<property>)-<date>.las
-    files = list(path.glob(f"{well_name.replace(' ', '_')}*.las"))
+    files = sorted(path.glob(f"{well_name.replace(' ', '_')}*.las"))
     dfs = [_read_las_file(file) for file in files]
 
     if not dfs:

--- a/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
+++ b/tests/jobs/well_trajectory/test_well_trajectory_resinsight.py
@@ -292,10 +292,10 @@ def test_reading_several_las_files(copy_testdata_tmpdir):
             "DEPTH": [8448.617, 8468.633, 8468.633, 8498.637, 8498.637, 8548.637],
             "TVDMSL": [8325.0, 8345.0, 8345.0, 8375.0, 8375.0, 8425.0],
             "TVDRKB": [8325.0, 8345.0, 8345.0, 8375.0, 8375.0, 8425.0],
-            "SOIL": [0.879899, 0.879899, 0.879900, 0.879900, 0.879901, 0.879901],
-            "PRESSURE": [4779.543, 4779.543, 4780.948, 4780.948, 4783.049, 4783.049],
             "PORO": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3],
             "ACTIVE_FORMATION_NAMES": [0.0, 0.0, 1.0, 1.0, 2.0, 2.0],
+            "SOIL": [0.879899, 0.879899, 0.879900, 0.879900, 0.879901, 0.879901],
+            "PRESSURE": [4779.543, 4779.543, 4780.948, 4780.948, 4783.049, 4783.049],
         }
     )
 
@@ -313,6 +313,6 @@ def test_reading_las_file_different_length(copy_testdata_tmpdir):
 
     with pytest.raises(
         ValueError,
-        match="LAS file INJ_SPE1CASE1-01_Jan_2015 has 4 rows, expected 6",
+        match="LAS file INJ_SPE1CASE1-02_Jan_2015 has 6 rows, expected 4",
     ):
         _read_and_merge_las(path=test_dir, well_name=well_name)


### PR DESCRIPTION
pathlib.Path.glob() doesn't guarentee specific order of reading the LAS files, when comparing DataFrames this can result in flaky behaviour. Just sort the list returned by glob.