### PR TITLE
Pin transitive dependency netcdf to avoidf 1.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "resdata",
     "Jinja2>=3.1.2",
+    "netCDF4!=1.7.4",  # transitive pin
     "numpy>=1.23.2",
     "ruamel.yaml>=0.17.21",
     "fmu-steaclient @ git+https://github.com/equinor/fmu-steaclient",


### PR DESCRIPTION
Version 1.7.4 observed to fail pip installation with:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
    return hook(config_settings)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/pip-build-env-kiaf05bz/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/pip-build-env-kiaf05bz/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
    self.run_setup()
  File "/tmp/pip-build-env-kiaf05bz/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
    exec(code, locals())
  File "<string>", line 297, in <module>
  File "<string>", line 244, in _populate_hdf5_info
ValueError: did not find HDF5 headers
```