### PR TITLE
Revert "Pin transitive dependency netcdf to avoidf 1.7.4"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 dependencies = [
     "resdata",
     "Jinja2>=3.1.2",
-    "netCDF4!=1.7.4",  # transitive pin
     "numpy>=1.23.2",
     "ruamel.yaml>=0.17.21",
     "fmu-steaclient @ git+https://github.com/equinor/fmu-steaclient",


### PR DESCRIPTION
This reverts commit 3ea1ea78f1db8cf1180198d0bcd68533e52944e6.

Should not be needed anymore; see https://github.com/equinor/ert/pull/12564#issuecomment-3713682857