### PR TITLE
Update ortools usage and workaround bug

### DIFF
--- a/src/everest_models/jobs/fm_drill_planner/planner/optimized.py
+++ b/src/everest_models/jobs/fm_drill_planner/planner/optimized.py
@@ -320,7 +320,7 @@ def run_optimization(
     logger.info("Optimization solver starting..")
 
     solution_printer = SolutionCallback()
-    status = solver.Solve(drill_constraint_model, solution_callback=solution_printer)
+    status = solver.solve(drill_constraint_model, solution_printer)
 
     logger.debug("Solver completed with status: %s", solver.StatusName(status))
     logger.debug(

--- a/tests/jobs/drill_planner/test_optimized_drill_planner.py
+++ b/tests/jobs/drill_planner/test_optimized_drill_planner.py
@@ -54,7 +54,7 @@ def satisfies(model, function_name, schedule):
     apply_schedule(model, schedule)
 
     solver = cp_model.CpSolver()
-    status = solver.Solve(model)
+    status = solver.solve(model)
 
     return status in [cp_model.FEASIBLE, cp_model.OPTIMAL]
 


### PR DESCRIPTION
A bug in ortools 9.15.6755 caused the call to fail. Update to the presumably future compatible syntax, and avoid naming the callback argument (for which there is buggy handling in ortools)

Code in this commit has been verified to work with both ortools 9.14 and 9.15.