### PR TITLE
Make ForwardModelSteps have correct module info

### DIFF
--- a/src/everest_models/forward_models.py
+++ b/src/everest_models/forward_models.py
@@ -27,6 +27,7 @@ if _HAVE_ERT:  # The everest-models package should remain installable without ER
                 "__init__": lambda x: ForwardModelStepPlugin.__init__(
                     x, name=fm_name, command=[f"fm_{fm_name}"]
                 ),
+                "__module__": __name__,
                 "documentation": lambda: ForwardModelStepDocumentation(
                     category="everest.everest_models",
                     source_package="everest_models",


### PR DESCRIPTION
Relates to equinor/ert#12729

When dynamically creating the ForwardModelStep type the __module__ attribute needs to be set explicitly to ensure that the correct module is associated with the type.