### PR TITLE
Allow reading wells from controls

### DIFF
--- a/src/everest_models/jobs/shared/models/wells.py
+++ b/src/everest_models/jobs/shared/models/wells.py
@@ -1,8 +1,8 @@
 from datetime import date
 from pathlib import Path
-from typing import Dict, Iterator, Tuple
+from typing import Any, Dict, Iterator, Tuple
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, model_validator
 from typing_extensions import Annotated
 
 from .base_config import ModelConfig, RootModelConfig
@@ -64,3 +64,10 @@ class Wells(RootModelConfig):
                 by_alias=True,
             )
         )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_dict_input(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            return [{"name": name} for name in data]  # noqa: B035
+        return data

--- a/tests/jobs/shared/models/test_wells.py
+++ b/tests/jobs/shared/models/test_wells.py
@@ -119,3 +119,23 @@ def test_legacy_well_model_missing_templates(well_model):
         ("rate", datetime.date.fromisoformat("2019-08-30")),
         ("rate", datetime.date.fromisoformat("2019-11-08")),
     )
+
+
+@pytest.mark.parametrize(
+    "control_dict",
+    [
+        {
+            "WELL1": 0.0,
+            "WELL2": 0.1,
+        },
+        {
+            "WELL1": {"1": 0.0},
+            "WELL2": {"1": 0.1},
+        },
+    ],
+)
+def test_well_model_from_controls(control_dict):
+    control_model = Wells.model_validate(control_dict)
+    for item in control_model:
+        assert isinstance(item, Well)
+    assert [item.name for item in control_model] == ["WELL1", "WELL2"]


### PR DESCRIPTION
Several models take a `wells.json` file parsing it into a `Wells `object. This PR allows parsing control files into `Well `objects as well. The resulting `Well `object will only have the `name `field set.

This will allow workflows that only require well names to use the corresponding control file to determine well names.

closes #238 
