### PR TITLE
Add a wells section to the drill_planner config

### DIFF
--- a/docs/reference/drill_planner/config.yml
+++ b/docs/reference/drill_planner/config.yml
@@ -2,6 +2,10 @@
 # <REPLACE> is a REQUIRED field that needs replacing
 
 
+# Required: False
+# Default: null
+wells: <REPLACE>
+
 # Datatype: date
 # Examples: 2024-01-31, 2024-01-31T11:06
 # Required: True

--- a/src/everest_models/jobs/fm_drill_planner/cli.py
+++ b/src/everest_models/jobs/fm_drill_planner/cli.py
@@ -104,9 +104,17 @@ def main_entry_point(args=None):
     args_parser = build_argument_parser()
     options = args_parser.parse_args(args)
 
+    if options.input is None and options.config.wells is None:
+        args_parser.error("-i/--input missing: `wells` is required in the config")
+    if options.input is not None and options.config.wells is not None:
+        args_parser.error(
+            "-i/--input and the `wells` config section are mutually exclusive"
+        )
+    wells = options.input if options.input is not None else options.config.wells
+
     manager = get_field_manager(
         options.config,
-        options.input,
+        wells,
         options.optimizer,
         options.ignore_end_date,
         options.lint,
@@ -115,6 +123,6 @@ def main_entry_point(args=None):
     if options.lint:
         args_parser.exit()
     orchestrate_drill_schedule(
-        manager, options.input.to_dict(), options.config.start_date, options.time_limit
+        manager, wells.to_dict(), options.config.start_date, options.time_limit
     )
-    options.input.json_dump(options.output)
+    wells.json_dump(options.output)

--- a/src/everest_models/jobs/fm_drill_planner/models/config.py
+++ b/src/everest_models/jobs/fm_drill_planner/models/config.py
@@ -7,6 +7,8 @@ from typing_extensions import Annotated
 
 from everest_models.jobs.shared.models import ModelConfig
 
+from .wells import Wells
+
 
 class _Unavailability(ModelConfig):
     start_date: ClassVar[date]
@@ -40,6 +42,7 @@ class Rig(_DrillSubject):
 
 
 class DrillPlanConfig(ModelConfig):
+    wells: Annotated[Wells | None, Field(default=None, description="")]
     start_date: Annotated[date, Field(description="")]
     end_date: Annotated[date, Field(description="")]
     rigs: Annotated[Tuple[Rig, ...], Field(description="")]

--- a/src/everest_models/jobs/fm_drill_planner/parser.py
+++ b/src/everest_models/jobs/fm_drill_planner/parser.py
@@ -30,12 +30,14 @@ def build_argument_parser(skip_type=False):
         "dates that are output will be a valid drill plan."
     )
     add_wells_input_argument(
-        required_group,
+        parser,
+        required=False,
         help="File containing information related to wells. The format is "
         "consistent with the wells.json file when running everest and can "
         "be used directly.",
         schema=Wells,
         skip_type=skip_type,
+        default=None,
     )
     add_output_argument(
         required_group,

--- a/tests/jobs/drill_planner/test_drill_planner_cli.py
+++ b/tests/jobs/drill_planner/test_drill_planner_cli.py
@@ -10,24 +10,64 @@ from everest_models.jobs.fm_drill_planner.manager import ScheduleError
 
 OUTPUT_FILENAME = "out.json"
 
+ARGS_WITH_WELLS = [
+    "--output",
+    OUTPUT_FILENAME,
+    "--optimizer",
+    "optimizer_values.yml",
+    "--input",
+    "wells.json",
+    "--config",
+    "config.yml",
+]
+ARGS_NO_WELLS = [
+    "--output",
+    OUTPUT_FILENAME,
+    "--optimizer",
+    "optimizer_values.yml",
+    "--config",
+    "config_wells.yml",
+]
+
 
 @pytest.fixture(scope="session")
 def drill_planner_arguments():
-    return [
-        "--output",
-        OUTPUT_FILENAME,
-        "--optimizer",
-        "optimizer_values.yml",
-        "--input",
-        "wells.json",
-        "--config",
-        "config.yml",
-    ]
+    return ARGS_WITH_WELLS
 
 
-def test_drill_planner_main_entry_point(drill_planner_arguments, copy_testdata_tmpdir):
+def test_drill_planner_main_entry_point_no_input_no_config(
+    copy_testdata_tmpdir, capsys
+):
     copy_testdata_tmpdir(TEST_DATA)
-    main_entry_point(drill_planner_arguments)
+    arguments = [
+        "config.yml" if item == "config_wells.yml" else item for item in ARGS_NO_WELLS
+    ]
+    with pytest.raises(SystemExit) as exc:
+        main_entry_point(arguments)
+    assert exc.value.code == 2
+    out = capsys.readouterr()
+    assert "error: -i/--input missing: `wells` is required in the config" in out.err
+
+
+def test_drill_planner_main_entry_point_input_and_config(copy_testdata_tmpdir, capsys):
+    copy_testdata_tmpdir(TEST_DATA)
+    arguments = [
+        "config_wells.yml" if item == "config.yml" else item for item in ARGS_WITH_WELLS
+    ]
+    with pytest.raises(SystemExit) as exc:
+        main_entry_point(arguments)
+    assert exc.value.code == 2
+    out = capsys.readouterr()
+    assert (
+        "error: -i/--input and the `wells` config section are mutually exclusive"
+        in out.err
+    )
+
+
+@pytest.mark.parametrize("arguments", (ARGS_WITH_WELLS, ARGS_NO_WELLS))
+def test_drill_planner_main_entry_point(copy_testdata_tmpdir, arguments):
+    copy_testdata_tmpdir(TEST_DATA)
+    main_entry_point(arguments)
 
     assert (
         pathlib.Path(OUTPUT_FILENAME).read_bytes()
@@ -134,9 +174,8 @@ def test_drill_planner_main_entry_point_ignore_end_date(
         main_entry_point([*drill_planner_arguments[:-1], "config_early_end_date.yml"])
 
 
-def test_drill_planner_main_entry_point_lint(
-    drill_planner_arguments, copy_testdata_tmpdir
-):
+@pytest.mark.parametrize("arguments", (ARGS_WITH_WELLS, ARGS_NO_WELLS))
+def test_drill_planner_main_entry_point_lint(copy_testdata_tmpdir, arguments):
     copy_testdata_tmpdir(TEST_DATA)
     with pytest.raises(SystemExit):
-        main_entry_point([*drill_planner_arguments, "--lint"])
+        main_entry_point([*arguments, "--lint"])

--- a/tests/testdata/drill_planner/config_wells.yml
+++ b/tests/testdata/drill_planner/config_wells.yml
@@ -1,0 +1,56 @@
+start_date: 2000-01-01
+end_date: 2001-01-01
+wells:
+- name: w1
+  drill_time: 20
+- name: w2
+  drill_time: 25
+- name: w3
+  drill_time: 43
+- name: w4
+  drill_time: 23
+- name: w5
+  drill_time: 36
+rigs:
+  -
+    name: 'A'
+    wells: ['w1', 'w2', 'w3']
+    slots: ['S1', 'S2', 'S3']
+    unavailability:
+      -
+        start: 2000-01-01
+        stop: 2000-02-02
+      -
+        start: 2000-03-14
+        stop: 2000-03-19
+  -
+    name: 'B'
+    wells: ['w3', 'w4', 'w5']
+    slots: ['S3', 'S4', 'S5']
+    unavailability:
+      -
+        start: 2000-02-01
+        stop: 2000-02-02
+      -
+        start: 2000-02-14
+        stop: 2000-02-15
+slots:
+  -
+    name: 'S1'
+    wells: ['w1', 'w2', 'w3']
+    unavailability:
+      -
+        start: 2000-02-01
+        stop: 2000-02-03
+  -
+    name: 'S2'
+    wells: ['w1', 'w2', 'w3']
+  -
+    name: 'S3'
+    wells: ['w1', 'w2', 'w3']
+  -
+    name: 'S4'
+    wells: ['w3', 'w4', 'w5']
+  -
+    name: 'S5'
+    wells: ['w3', 'w4', 'w5']


### PR DESCRIPTION
Because the well section will eventually be removed from the everest configuration, the `wells.json` file may not exist. This PR adds an optional section to the configuration of `drill_planner` which can be used to replace the `wells.json` file.

closes: #241 