### PR TITLE
Resolve pytest warning on PytestUnknownMarkWarning

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -1,6 +1,7 @@
 copy_test_files () {
     cp -r ${CI_SOURCE_ROOT}/tests ${CI_TEST_ROOT}/tests
     cp -r ${CI_SOURCE_ROOT}/docs ${CI_TEST_ROOT}/docs
+    cp ${CI_SOURCE_ROOT}/pyproject.toml $CI_TEST_ROOT
 }
 
 install_test_dependencies () {


### PR DESCRIPTION
When running tests through komodo, pytest claims 'slow' (and others) is an unknown mark. This is due to pyproject.toml, which defines it, not being present where it is running the tests