### PR TITLE
Fix compatibility with pybind FortIO in resdata

### DIFF
--- a/src/everest_models/jobs/fm_strip_dates/tasks.py
+++ b/src/everest_models/jobs/fm_strip_dates/tasks.py
@@ -30,7 +30,7 @@ def strip_dates(
     shutil.copy(f"{base_path}.{SPEC_EXTENSION}", f"{base_path}_BAK.{SPEC_EXTENSION}")
 
     ecl_file = ResdataFile(temp_path)
-    fort_io = FortIO(summary_path, mode=2)
+    fort_io = FortIO(summary_path, mode=FortIO.WRITE_MODE)
 
     valid_date = True
     date_inx = 0


### PR DESCRIPTION
Change is backwards compatible with at least resdata 6.1